### PR TITLE
chore(claude): adapta template .claude ao projeto real do aque-web

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,14 @@
+---
+name: code-reviewer
+description: Revisa código quanto a corretude, segurança e manutenibilidade. Use após implementar uma feature ou antes de abrir um PR.
+tools: Read, Grep, Glob
+---
+
+Você é um revisor de código sênior. Revise focando em:
+
+1. **Corretude**: erros de lógica, edge cases, tratamento de null/undefined
+2. **Segurança**: injeção, bypass de autenticação, exposição de dados
+3. **Manutenibilidade**: nomes, complexidade, duplicação
+4. **Aderência às convenções do projeto**: consulte CLAUDE.md e `.claude/rules/` antes de reportar
+
+Cada achado deve incluir uma sugestão de correção concreta. Não edite arquivos — apenas reporte.

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,0 +1,14 @@
+---
+name: debugger
+description: Investiga bugs e falhas de teste, isolando a causa raiz antes de propor uma correção. Use quando um teste falha ou um comportamento inesperado é reportado.
+tools: Read, Grep, Glob, Bash
+---
+
+Você é um especialista em debugging. Para cada investigação:
+
+1. Reproduza o problema (rode o teste ou comando que falha)
+2. Isole a causa raiz — não pare no primeiro sintoma
+3. Verifique se o mesmo padrão de bug existe em outros lugares do código
+4. Proponha a correção mínima necessária, explicando o porquê
+
+Se precisar editar arquivos para corrigir, peça confirmação explicando a mudança antes de aplicar.

--- a/.claude/rules/code-style-frontend.md
+++ b/.claude/rules/code-style-frontend.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "src/app/**/*.ts"
+  - "src/app/**/*.html"
+---
+
+# Estilo de código — Frontend (Angular/TypeScript)
+
+- Identificadores (classes, funções, variáveis) em inglês; comentários em português —
+  ver regra geral em `standards.md`
+- Standalone components apenas — nunca `NgModule`
+- Estado com **Signals**, nunca `BehaviorSubject`/store externo: `signal()` privado com
+  prefixo `_`, exposto como `readonly` público via `.asReadonly()`; `computed()` para
+  derivado; `effect()` só para side effect (ex.: disparar carga inicial no construtor)
+- Formulários com **Signal Forms** (`@angular/forms/signals`) — nunca `ReactiveFormsModule`.
+  Referência: `src/app/features/transactions/transaction-form/transaction-form.component.ts`
+- Um service por recurso do backend em `src/app/core/services/`, sempre
+  `@Injectable({ providedIn: 'root' })`, com `Observable<T>` nos métodos HTTP; interfaces de
+  payload/filtro ficam no mesmo arquivo do service, não em `core/models/`
+- Guards/interceptors como funções (`CanActivateFn`, `HttpInterceptorFn`), nunca classes
+- Exports nomeados; um componente/service/pipe por arquivo, nome do arquivo = `<nome>.<tipo>.ts`
+- Tipagem explícita em props e retornos; evitar `any` (ver débitos conhecidos em
+  `.claude/docs/CONCERNS.md`)
+- Tailwind v4 via utilitários já definidos em `src/styles.css` (`.ledger-*`, `.btn-*`,
+  `.badge-*`) — reutilize antes de criar classe nova; estilo local pequeno via `styles: [...]`
+  inline no componente, não arquivo `.css` separado
+- Sem ESLint neste projeto — formatação garantida só por Prettier (config em `package.json`)
+
+Padrões mais profundos (arquitetura, fluxo de dados, convenções de nomenclatura completas) estão
+em `.claude/docs/CONVENTIONS.md` e `.claude/docs/ARCHITECTURE.md` — consulte antes de duplicar
+regra aqui.

--- a/.claude/rules/general-best-practices.md
+++ b/.claude/rules/general-best-practices.md
@@ -1,0 +1,45 @@
+# Boas práticas gerais
+
+Aplica-se a todo o repositório, independente de linguagem ou stack.
+
+## Nomenclatura
+- Nomes descritivos e sem abreviação forçada: `calculateOrderTotal`, não `calcOrdTot`
+- Booleanos com prefixo de pergunta: `isActive`, `hasPermission`, `canEdit`
+- Evite nomes genéricos (`data`, `info`, `temp`, `handler`) quando um nome específico é possível
+- Idioma do código é inglês — ver regra obrigatória em `standards.md`
+
+## Git e commits
+- Conventional Commits: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`
+- Um commit = uma mudança lógica; evite commits "ajustes diversos"
+- Branch a partir de `main`/`develop` atualizada; nomeie como `feat/nome-da-feature` ou `fix/descricao-do-bug`
+- Nunca commitar arquivos gerados (build, node_modules, target) — confira `.gitignore` antes de criar algo novo
+
+## Tratamento de erros
+- Nunca engula exceções silenciosamente (`catch {}` vazio); ao menos logue
+- Erros de negócio são explícitos e tipados — evite lançar `Exception`/`Error` genérico
+- Mensagens de erro voltadas ao usuário são claras e acionáveis; mensagens técnicas detalhadas vão para o log, não para a resposta
+
+## Funções e complexidade
+- Funções fazem uma coisa; se o nome precisa de "e" (`saveAndSendEmail`), provavelmente deveria ser duas funções
+- Prefira retornar cedo (early return) a aninhar `if`s profundamente
+- Evite "números mágicos" e strings soltas no meio do código — extraia para constantes nomeadas
+- Não duplique lógica de negócio em mais de um lugar; extraia para uma função/serviço compartilhado
+
+## Dependências
+- Antes de adicionar uma lib nova, verifique se já existe algo equivalente no projeto
+- Fixe versões (sem `^`/`~` soltos em libs críticas) para builds reproduzíveis
+- Remova imports e dependências não utilizados antes de abrir o PR
+
+## Configuração e segredos
+- Nada de valores de ambiente (URLs, chaves, flags) hardcoded — usar variáveis de ambiente/config
+- Um `.env.example` sempre atualizado, sem valores reais, documentando o que é necessário
+
+## Documentação
+- Comentários explicam o "porquê", não o "o quê" (o código já diz o quê)
+- Funções públicas/exportadas com propósito não óbvio merecem uma linha de doc
+- Atualize o README quando um comando de setup ou execução mudar
+
+## Revisão de código
+- PRs pequenos e focados; se o diff passar de ~400 linhas, considere quebrar
+- Todo PR descreve o que mudou e por quê (use a skill `/gerar-pr`)
+- Não aprove o próprio PR; peça revisão de outra pessoa do time

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,18 @@
+# Segurança
+
+Este repo é só o frontend (SPA Angular) — validação de entrada, queries parametrizadas e
+regras de autorização de endpoint são responsabilidade do `aque-backend`. As regras abaixo
+cobrem o que é responsabilidade do frontend.
+
+- Nunca commitar segredos, tokens ou senhas — usar variáveis de ambiente e `.env` (gitignorado);
+  hoje o projeto não usa `.env`/env vars em build (ver `.claude/docs/STACK.md`)
+- Rotas autenticadas por padrão via `authGuard` (`src/app/core/auth/auth.guard.ts`); rota pública
+  nova precisa de justificativa no PR
+- Nunca usar `innerHTML`/`bypassSecurityTrust*` para renderizar conteúdo vindo do usuário ou do
+  backend — depender da sanitização padrão do Angular
+- JWT fica em `localStorage` (`aque_token`) — risco conhecido e aceito (ver
+  `.claude/docs/CONCERNS.md`); não introduzir um segundo mecanismo de storage sem decisão
+  explícita
+- Dependências novas passam por `npm audit` antes do merge
+- Dados sensíveis de usuário (CPF, e-mail, telefone) nunca aparecem em logs/console nem em
+  mensagens de toast de erro

--- a/.claude/rules/standards.md
+++ b/.claude/rules/standards.md
@@ -1,0 +1,100 @@
+# Padrões obrigatórios do time
+
+Aplicam-se a todo repositório, independente de linguagem. Diferente das outras rules,
+esta não deve ser removida ou relaxada ao adaptar o template — apenas os comandos e
+ferramentas de exemplo devem ser ajustados para a stack de cada repositório.
+
+## Idioma do código
+
+Duas camadas, dois idiomas:
+
+- **Identificadores em inglês**: nomes de variáveis, funções, métodos, classes,
+  interfaces, tabelas/colunas de banco e branches
+- **Prosa em português**: comentários, descrições de teste (`describe`/`it`),
+  mensagens de assert e mensagens de commit (corpo e resumo — os tipos do
+  Conventional Commits como `feat`/`fix` continuam em inglês, são token de formato,
+  não prosa)
+- Termos de domínio de negócio específicos do time (nomes próprios, siglas internas sem
+  tradução natural) podem permanecer como estão — não force uma tradução artificial
+- Commits seguem o mesmo padrão — ver skill `commit-msg`
+- **Código legado**: essa regra vale para código novo. Não renomeie em massa
+  identificadores ou traduza comentários/testes existentes só para adequá-los ao
+  padrão — isso é um refactor arriscado (quebra referências, integrações, histórico
+  de `git blame`). Ajustar código legado é uma decisão à parte, feita de forma
+  isolada e deliberada, nunca como efeito colateral de outra tarefa
+
+### Exemplos
+```typescript
+// Sim
+export class TransactionService {
+  // recalcula o total considerando splits pendentes, não só os pagos
+  calculateTotal(transaction: Transaction): number { ... }
+  isTransactionEditable(transaction: Transaction): boolean { ... }
+}
+
+describe('TransactionService', () => {
+  it('deve retornar 0 quando não há splits pendentes', () => { ... });
+});
+
+// Não (comentário/teste em inglês, identificador não deveria virar português)
+export class TransactionService {
+  // recalculates the total considering pending splits
+  calculateTotal(transaction: Transaction): number { ... }
+}
+
+export class ServicoDeTransacao {
+  calcularTotal(transacao: Transacao): number { ... }
+}
+```
+
+## Commits e versionamento
+- Conventional Commits obrigatório: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`, `perf:`, `ci:`
+- Versionamento semântico automático a partir dos commits (ex: semantic-release) —
+  nunca bump de versão manual no `package.json`. **Gap conhecido no aque-web**:
+  semantic-release ainda não está configurado — `package.json` fica em `0.0.0`
+- Mudança que quebra compatibilidade usa `!` no tipo (`feat!:`) ou rodapé `BREAKING CHANGE:`
+- Use a skill `commit-msg` para gerar a mensagem (formato completo com escopo, prefixo
+  de ticket extraído da branch) e executar o commit diretamente — não escreva
+  a mensagem manualmente sem seguir esse padrão
+
+## Desenvolvimento orientado a testes (TDD)
+- Ciclo red → green → refactor: escreva o teste que falha antes de implementar
+- Nenhuma função ou endpoint novo é implementado sem um teste que existia primeiro e falhava
+- Ao alterar código legado sem teste, adicione um teste de regressão antes de mexer
+
+## Pre-commit hooks
+- Lint e format rodam automaticamente antes de cada commit local
+  (ex: Husky + lint-staged para Node, framework `pre-commit` para outras stacks)
+- O commit é bloqueado localmente se lint/format falhar — não depender só do CI para isso
+- **Gap conhecido no aque-web**: não há Husky/lint-staged configurado hoje — só o
+  hook `PostToolUse` do Claude Code roda `prettier --write` após edições. Format
+  roda, mas nada bloqueia um commit com problema de lint (não há ESLint no projeto)
+
+## Definition of Done
+Uma task só é considerada concluída quando:
+- [ ] Código implementado e testado (unitário + integração quando aplicável)
+- [ ] Lint e testes passando localmente e no CI
+- [ ] PR revisado e aprovado por outra pessoa
+- [ ] Documentação relevante atualizada (README, CLAUDE.md, comentários de API)
+- [ ] Sem TODOs ou débitos técnicos não documentados/registrados
+
+**Gap conhecido no aque-web**: o workflow do GitHub Actions (`docker-publish.yml`) só
+builda e publica a imagem Docker no push pra `main` — não roda `npm test` nem lint.
+"Lint e testes passando no CI" não é hoje verificável automaticamente neste repo.
+
+## Template de Pull Request
+Todo PR segue esta estrutura (a skill `/gerar-pr` já gera isso automaticamente):
+- **Contexto**: o que motivou a mudança
+- **Mudanças**: lista do que foi alterado
+- **Como testar**: passos para validar manualmente
+- **Checklist**: testes adicionados, docs atualizadas, breaking changes (sim/não)
+
+**Gap conhecido no aque-web**: não existe `.github/PULL_REQUEST_TEMPLATE.md` —
+esse template só é aplicado quando a skill `/gerar-pr` monta a descrição.
+
+## Logging estruturado
+- Logs em formato estruturado (JSON), nunca `print`/`console.log` solto em produção
+- Campos padrão em todo log: `timestamp`, `level`, `service`, `traceId` (ou correlation ID equivalente)
+- Nunca logar dados sensíveis — ver `security.md`
+- Nível correto: `error` para falhas reais, `warn` para degradação, `info` para eventos
+  de negócio, `debug` só em ambiente de desenvolvimento

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,43 @@
+---
+paths:
+  - "src/app/**/*.spec.ts"
+---
+
+# Convenções de testes
+
+- Nomeie testes descrevendo comportamento, em português: `'deve [resultado esperado] quando
+  [condição]'` — é o padrão já usado em todos os specs existentes
+- Um teste testa uma coisa só — evite múltiplos asserts não relacionados no mesmo teste
+- Mocks apenas para dependências externas (o backend via `HttpTestingController`); nunca mocke
+  o próprio código sob teste — services reais são injetados via `TestBed`
+- Toda função pública nova precisa de teste cobrindo o caminho feliz e pelo menos um caso de erro
+
+## Framework e organização
+
+- **Runner:** Karma + Jasmine (`npm test`), sem `karma.conf.js` próprio — configurado via
+  `angular.json`/`tsconfig.spec.json` (padrão do Angular CLI)
+- Specs **co-localizados**: `<nome>.service.spec.ts` ao lado de `<nome>.service.ts`
+- Sem diretório de fixtures compartilhado — factory function local por arquivo de spec
+  (`function summary(overrides: Partial<X>): X { return { ...defaults, ...overrides }; }`)
+
+## Mocking HTTP
+
+```typescript
+TestBed.configureTestingModule({
+  providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+});
+httpMock = TestBed.inject(HttpTestingController);
+
+httpMock.expectOne(`${base}/summary/${year}/${month}`).flush(summary({}));
+```
+
+- `http.verify()` no `afterEach` para garantir que não sobrou request pendente
+- `localStorage.clear()` em `beforeEach`/`afterEach` em qualquer spec que toque `AuthService`
+- Erros de subscribe são checados via flag booleana setada no callback `error`, não
+  `catchError`/async-await
+
+## Cobertura
+
+Sem threshold obrigatório. `npx ng test --code-coverage` usa o `karma-coverage` já instalado.
+
+Mais exemplos e padrões completos em `.claude/docs/TESTING.md`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,33 @@
-{}
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test *)",
+      "Bash(npm run *)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git status)",
+      "Bash(git commit *)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force*)",
+      "Bash(git push origin main)",
+      "Read(./**/.env)",
+      "Read(./**/*.pem)",
+      "Read(./**/secrets/**)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "case \"$(jq -r '.tool_input.file_path')\" in *.ts|*.html) npx prettier --write \"$(jq -r '.tool_input.file_path')\" ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/commit-msg/SKILL.md
+++ b/.claude/skills/commit-msg/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: commit-msg
+description: Use this skill when the user asks to "write a commit message", "generate a commit", "create a commit", "fazer commit", "mensagem de commit", "gerar commit", or when staging changes and preparing a git commit. Provides rules for Conventional Commits format in Portuguese with scope and ticket prefix from branch name, and commits directly.
+version: 2.0.0
+---
+
+# Instruções de geração de mensagem de commit
+
+## Idioma
+- Sempre escreva a mensagem de commit em **português**. O tipo do Conventional Commits
+  (`feat`, `fix`, etc.) é um token de formato e continua em inglês — só o resumo e o
+  corpo vão em português.
+
+## Formato
+- Use o padrão **Conventional Commits**.
+- Sempre inclua o **escopo** entre parênteses após o tipo.
+- Escolha o tipo correto pela tabela abaixo:
+
+| Tipo | Quando usar |
+|------|------------|
+| `feat` | Nova funcionalidade para o usuário ou sistema |
+| `fix` | Correção de bug |
+| `refactor` | Reestruturação de **código-fonte** sem mudar comportamento (renomear variáveis, extrair métodos, reorganizar classes) |
+| `chore` | Manutenção que **não muda código-fonte nem testes** (configs, `.env`, `.gitignore`, dependências, scripts de build) |
+| `docs` | Mudanças só em documentação (README, comentários, CLAUDE.md) |
+| `style` | Formatação sem mudar lógica (espaço, indentação, ponto e vírgula) |
+| `test` | Adicionar ou corrigir testes |
+| `perf` | Melhoria de performance |
+| `ci` | Mudanças em pipeline de CI/CD (GitHub Actions) |
+| `build` | Mudanças no sistema de build (`package.json`, `angular.json`, `Dockerfile`) |
+| `revert` | Reverter um commit anterior |
+
+### Regras importantes na escolha do tipo
+- Arquivos de config (`.env`, `.gitignore`, `proxy.conf.json`) → `chore`
+- Mudanças em `package.json` (deps), `angular.json`, `Dockerfile` → `build`
+- **Nunca** use `refactor` para arquivos que não são código-fonte (configs, scripts, docs)
+
+## Primeira linha (subject)
+
+### Estrutura
+```
+[TASK-XXX] tipo(escopo): resumo imperativo do que foi feito
+```
+
+### Regras
+1. Confira o nome da branch atual.
+2. Se a branch começar com um padrão de ticket (ex.: `TASK-123`, `ORD-456`, `BUG-789` —
+   qualquer prefixo seguido de hífen e números), extraia essa referência e coloque no
+   **início** da primeira linha entre colchetes.
+3. Se a branch **não** tiver referência de ticket — caso comum neste projeto, cujas
+   branches seguem `feature/nome-da-feature` ou `fix/descricao-do-bug` sem ticket —
+   omita os colchetes e comece direto com o tipo.
+4. O resumo deve estar no **modo imperativo** (ex.: "adiciona", "corrige", "remove",
+   "atualiza").
+5. Primeira letra do resumo em **minúscula**.
+6. **Não** termine com ponto.
+7. **Não** use emojis.
+
+### Exemplos
+- Branch `TASK-123-add-order-filter`:
+  ```
+  [TASK-123] feat(orders): adiciona filtro de pedidos por status
+  ```
+- Branch `feature/dark-mode-and-dashboard-cards` (sem ticket, padrão real deste projeto):
+  ```
+  feat(dashboard): adiciona modo escuro e cards de resumo
+  ```
+
+## Corpo do commit
+
+Escreva o corpo pensando no revisor, não como changelog — o objetivo é que quem
+revisa entenda o *raciocínio* sem precisar abrir o diff inteiro.
+
+- Inclua corpo **só quando necessário** (mudanças complexas, decisões não óbvias,
+  qualquer coisa que o revisor perguntaria de qualquer forma)
+- Separe o corpo da primeira linha com uma **linha em branco**
+- Divida o corpo em **bullet points** usando `-`
+- Cada bullet explica o **porquê**, não só o quê: o raciocínio, trade-off ou contexto
+  por trás da mudança — não uma repetição do diff
+- Mantenha curto e objetivo; se precisar de mais de ~5 bullets, a mudança
+  provavelmente é grande demais para um commit só — considere quebrar
+
+### Exemplo com corpo
+```
+feat(split): adiciona cancelamento de rateio pendente
+
+- Cancelamento só permitido antes da confirmação, pra evitar inconsistência com
+  transações já geradas a partir do split
+- Optei por um endpoint dedicado em vez de um PATCH genérico pra deixar a transição
+  de status explícita e fácil de validar
+```
+
+### Exemplo com corpo mínimo
+```
+chore(config): atualiza regras do gitignore
+```
+
+## Breaking Changes
+
+- Para mudanças que quebram compatibilidade, adicione `BREAKING CHANGE:` no
+  **corpo** da mensagem.
+- Descreva o que mudou e o impacto.
+
+### Exemplo
+```
+refactor(auth): muda estrutura do token de autenticação
+
+- Migra de JWT simples para JWT com claims customizadas, necessário pra carregar
+  informação de papel sem uma consulta extra a cada request
+
+BREAKING CHANGE: formato do token mudou, clientes precisam atualizar o parser
+```
+
+## Autoria do commit
+
+- **Nunca** adicione `Co-Authored-By` ou qualquer referência ao assistente na
+  mensagem de commit.
+- O commit deve conter só a autoria do usuário.
+
+## Execução
+
+- Monte a mensagem de commit seguindo as regras acima e rode `git commit` com ela
+  **diretamente** — não peça aprovação antes.
+- Depois de commitar, mostre ao usuário a mensagem exata que foi commitada, pra ele
+  poder corrigir com amend se algo estiver errado.
+- **Nunca** rode `git push` — só commit local.

--- a/.claude/skills/gerar-pr/SKILL.md
+++ b/.claude/skills/gerar-pr/SKILL.md
@@ -1,0 +1,17 @@
+---
+description: Gera uma descrição de Pull Request em português a partir das mudanças da branch atual
+argument-hint: [branch-base]
+---
+
+## Mudanças desde a base
+
+!`git diff $ARGUMENTS...HEAD --stat`
+!`git log $ARGUMENTS...HEAD --oneline`
+
+Com base nas mudanças acima, gere uma descrição de PR em português com:
+
+1. **Resumo** — o que foi feito, em 1-2 frases
+2. **Motivação** — por que essa mudança foi necessária
+3. **Mudanças** — lista dos principais pontos alterados
+4. **Como testar** — passos para validar manualmente
+5. **Checklist** — testes adicionados, docs atualizadas, breaking changes (sim/não)

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+description: Revisa mudanças de código em busca de vulnerabilidades de segurança, falhas de autenticação e riscos de injeção
+disable-model-invocation: true
+argument-hint: <branch-ou-path>
+---
+
+## Diff a revisar
+
+!`git diff $ARGUMENTS`
+
+Audite as mudanças acima quanto a:
+
+1. Vulnerabilidades de injeção (SQL, XSS, command injection)
+2. Falhas de autenticação e autorização
+3. Segredos ou credenciais hardcoded
+4. Validação de entrada ausente
+
+Use o checklist.md nesta pasta como referência completa.
+
+Reporte cada achado com nível de severidade e sugestão de correção.

--- a/.claude/skills/security-review/checklist.md
+++ b/.claude/skills/security-review/checklist.md
@@ -1,0 +1,24 @@
+# Checklist de revisão de segurança (frontend SPA)
+
+Este repo é só o frontend. Validação server-side, SQL, hashing de senha e autorização de
+endpoint são revisados no `aque-backend`, não aqui.
+
+## Renderização e sanitização
+- [ ] Nenhum uso de `innerHTML`, `[innerHTML]` ou `bypassSecurityTrust*` com conteúdo vindo do
+  usuário ou do backend sem justificativa
+- [ ] Nenhuma URL montada dinamicamente (`href`, `src`) a partir de input não validado
+
+## Autenticação e sessão
+- [ ] Rota nova sob `AppShellComponent` está protegida por `authGuard`; se for pública, o PR
+  justifica por quê
+- [ ] Nenhum código novo lê/escreve o token JWT fora de `AuthService`
+- [ ] Resposta 401/403 continua tratada só pelo `authInterceptor`, não duplicada por componente
+
+## Dados sensíveis
+- [ ] Nenhum dado sensível (CPF, e-mail, telefone, token) aparece em `console.log`, mensagem de
+  toast ou comentário deixado no código
+- [ ] Erros HTTP mostrados ao usuário não vazam detalhes internos (stack trace, URL de API,
+  versão de lib) — mensagem genérica via `ToastService`
+
+## Dependências
+- [ ] Dependência nova rodou `npm audit` sem vulnerabilidade alta/crítica sem mitigação

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,89 +1,61 @@
-# CLAUDE.md
+# Convenções do Projeto
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+> Este arquivo é a fonte da verdade para qualquer dev ou IA trabalhando neste repositório.
+> Mantenha abaixo de 200 linhas — detalhes específicos ficam em `.claude/rules/` e `.claude/docs/`.
 
-## Commands
+## Estrutura do repositório
 
-```bash
-# Development server (proxies /api to localhost:8080)
-npm start
+SPA Angular puro — sem backend neste repo (o `aque-backend`, Spring Boot, é um repo irmão).
 
-# Build for production
-npm run build
+- `src/app/core/` — services de acesso a dados (um por recurso do backend), auth (`AuthService`,
+  `authGuard`, `authInterceptor`), modelos/enums compartilhados
+- `src/app/features/` — um diretório por rota (dashboard, transactions, categories, persons,
+  recurring, split, login), standalone components
+- `src/app/layout/` — chrome autenticado (`AppShellComponent`, sidebar, header)
+- `src/app/shared/` — componentes/pipes/services genéricos e sem conhecimento de domínio
+- `.claude/rules/` — convenções detalhadas por área (carregadas sob demanda)
+- `.claude/docs/` — referência mais profunda de arquitetura, stack, testes, integrações e débitos
+  técnicos (`ARCHITECTURE.md`, `STACK.md`, `TESTING.md`, `CONVENTIONS.md`, `CONCERNS.md`, etc.)
+- `.claude/skills/` — fluxos reutilizáveis (`commit-msg`, `/gerar-pr`, `/security-review`)
+- `.claude/agents/` — subagentes especializados (`code-reviewer`, `debugger`)
+- `.agents/skills/angular-developer/` — referência de padrões Angular consumida por agentes de IA
 
-# Run all tests (headless via Karma + Jasmine)
-npm test
+## Comandos
 
-# Run tests for a specific file
-npx ng test --include='**/auth.service.spec.ts'
+- Instalar deps: `npm install`
+- Dev server: `npm start` (proxy `/api` → `aque-backend` em `localhost:8080`, ver `proxy.conf.json`)
+- Build: `npm run build`
+- Testes: `npm test` (Karma + Jasmine, headless Chrome)
+- Rodar um spec específico: `npx ng test --include='**/auth.service.spec.ts'`
 
-# Watch build
-npm run watch
-```
+Não há `npm run lint` — não há ESLint configurado neste projeto; estilo é garantido só por
+Prettier (config embutida no `package.json`) + TypeScript strict.
 
-## Architecture
+## Stack
 
-**AqueWeb** is an Angular 21 personal finance SPA (standalone components, no NgModules). It communicates with a backend at `localhost:8080` via the dev proxy in `proxy.conf.json` — all HTTP calls use the `/api` prefix.
+- **Frontend**: Angular 21 (standalone components, Signals, Signal Forms), TypeScript 5.9 strict,
+  RxJS, Tailwind CSS v4 (PostCSS), ApexCharts/`ng-apexcharts`
+- **Testes**: Karma + Jasmine (`karma-coverage` instalado, sem threshold obrigatório)
+- **CI/CD**: GitHub Actions builda e publica a imagem Docker no push pra `main`
+  (`docker-publish.yml`) — não roda lint nem teste
+- **Deploy**: Nginx servindo o build estático, Raspberry Pi 3B via Docker Compose
 
-### State management approach
+## Regras gerais
 
-The app uses Angular Signals throughout — no NgRx or RxJS `BehaviorSubject` for state. Key pattern:
-- Services expose `readonly` signals (`signal.asReadonly()`) for state consumers
-- `computed()` derives values from signals
-- `effect()` is used sparingly for side effects
+- Nunca commitar direto na `main` — sempre via PR
+- Todo PR precisa passar lint + testes no CI antes do merge (hoje o CI só builda a imagem —
+  gap conhecido, ver `.claude/rules/standards.md`)
+- Mensagens de commit no padrão Conventional Commits (`feat:`, `fix:`, `chore:`...)
+- Identificadores de código em inglês; comentários, testes e mensagens de commit em português —
+  ver `.claude/rules/standards.md`
+- Regras detalhadas de estilo, testes e segurança estão em `.claude/rules/` e carregam
+  automaticamente conforme os arquivos que você tocar
 
-**`MonthYearService`** (`src/app/core/services/month-year.service.ts`) is the global month/year selector. Features read `monthYear.month()` and `monthYear.year()` to scope their API calls. When the user navigates months in the header, all views react automatically.
+## Fluxos comuns
 
-### Forms
-
-Forms use Angular's experimental **Signal Forms** API (`@angular/forms/signals`): `form()`, `FormField`, `required()`, `min()`. This is **not** the standard `ReactiveFormsModule`. See `transaction-form.component.ts` for the canonical usage pattern.
-
-### Folder structure
-
-```
-src/app/
-  core/
-    auth/         # AuthService (signal-based), authGuard, authInterceptor
-    models/       # All shared interfaces + enums (re-exported from index.ts)
-    services/     # One service per domain (transaction, category, person, recurring, split, dashboard)
-  features/       # Route-level components (dashboard, transactions, recurring, categories, persons, split, login)
-  layout/         # AppShellComponent (sidebar + header + router-outlet), SidebarComponent, HeaderComponent
-  shared/
-    components/toast/  # ToastComponent
-    pipes/             # BrlCurrencyPipe, MonthYearPipe
-    services/          # ToastService
-```
-
-### Auth flow
-
-`AuthService` stores the JWT in `localStorage` under key `aque_token`. `authInterceptor` injects the `Authorization: Bearer` header on every request and calls `auth.logout()` on 401 **or** 403. `authGuard` protects all routes under the `AppShellComponent` layout.
-
-**401 vs 403 contract with `aque-backend`:** the backend only returns `401` for wrong credentials at `POST /auth/login` (handled inline by `login.component.ts`, not the interceptor). A missing, invalid, or expired token on any protected route returns `403` — Spring Security's default for an unauthenticated request past the `JwtFilter`, not a "true" authorization failure. `authInterceptor` treats both as "not logged in" and logs out. This is an implicit behavior contract, not enforced by a shared type or a test spanning both repos — a change to `aque-backend`'s `SecurityConfig`/exception handling that starts returning a different status for expired tokens would silently break logout-on-expiry here. See the matching note in `aque-backend/CLAUDE.md`.
-
-### Styling
-
-- **Tailwind CSS v4** (PostCSS plugin, no config file) — the entire design system is CSS-based config in `src/styles.css` via `@theme`
-- Light "ledger" (cream/paper) theme by default via CSS custom properties (`--color-ledger-*`) in `src/styles.css`, with an opt-in dark mode: `@custom-variant dark (&:where(.dark, .dark *))` plus a `.dark { ... }` block redefining every `--color-ledger-*` token. Toggled by `ThemeService` (`core/services/theme.service.ts`), which adds/removes the `.dark` class on `<html>`, persists the choice in `localStorage`, and defaults to OS preference (`prefers-color-scheme`) on first load
-- Reusable classes: `.ledger-card`, `.ledger-input`, `.ledger-label`, `.ledger-table`, `.btn-primary`/`-secondary`/`-ghost`/`-danger`, `.badge-paid`/`-pending`/`-income`/`-expense`
-- Fonts: **Crimson Pro** (serif/display) and **DM Mono** (numeric/mono) from Google Fonts
-
-### Charts
-
-Dashboard uses **ng-apexcharts** (`ng-apexcharts` + `apexcharts`). Chart option types are defined locally in `dashboard.component.ts` (`PieChartOptions`, `LineChartOptions`).
-
-### Domain models
-
-All interfaces live in `src/app/core/models/index.ts`. Key types:
-- `Transaction` — has `referenceMonth`/`referenceYear`, `amountExpected`/`amountPaid`, `status: PENDENTE|PAGO`
-- `RecurringTransaction` — template that generates monthly transactions; linked via `recurringId` on `Transaction`
-- `SplitRule` / `SplitResult` — per-month expense split among `Person` entries by percentage 
-
-## Reference docs
-
-Deeper, verified-against-code analysis lives in `.claude/docs/`: `ARCHITECTURE.md` (layers, data flow, anti-patterns), `CONVENTIONS.md` (naming, error handling, style), `STACK.md` (dependencies, versions), `STRUCTURE.md` (where to add new code), `TESTING.md` (test patterns/fixtures), `INTEGRATIONS.md` (external services, env vars), `CONCERNS.md` (tech debt, known gaps, fragile areas). Read the relevant one before a structural change or when this file doesn't have the answer.
-
-## Key decisions
-
-- **Signals over NgRx** — simpler state for a small, single-domain app.
-- **Signal Forms over `ReactiveFormsModule`** — experimental Angular API, chosen deliberately to align with the Signals-first approach.
-- **JWT in `localStorage`, not an httpOnly cookie** — acceptable risk for a single-user personal app; revisit only if the XSS threat model changes.
+- Revisão de segurança de um diff: `/security-review`
+- Gerar descrição de PR a partir do git diff: `/gerar-pr`
+- Gerar mensagem de commit (Conventional Commits, em português, com prefixo de ticket da branch
+  quando houver): skill `commit-msg` — ativa automaticamente ao pedir para "fazer commit" ou
+  "gerar mensagem de commit"
+- Para revisão de código isolada (sem editar nada), delegue ao subagente `code-reviewer`


### PR DESCRIPTION
## Contexto

O `.claude/` (CLAUDE.md, rules, skills, agents) tinha sido colado como template genérico
(exemplos de backend Java/Spring e frontend React/Vite) e não refletia o projeto real:
aque-web é uma SPA Angular pura, sem backend neste repo.

## Mudanças

- **CLAUDE.md**: estrutura real (`src/app/core|features|layout|shared`), comandos reais
  (`npm start`, sem `npm run lint` — não há ESLint), stack real (Angular 21 standalone +
  Signals, TypeScript strict, Tailwind v4)
- **`.claude/rules/code-style-backend.md`, `api-design.md`**: removidos (sem
  backend/controllers neste repo)
- **`code-style-frontend.md`**: reescrito para os padrões reais (Signals, Signal Forms,
  services `providedIn: 'root'`)
- **`testing.md`**: reescrito para Karma + Jasmine (specs co-localizados,
  `HttpTestingController`), com `describe`/`it` em português como padrão — é o que 100%
  dos 19 specs existentes já fazem
- **`security.md`** e **`security-review/checklist.md`**: trocados de checklist
  backend-cêntrico (SQL, bcrypt, upload) para riscos reais do SPA (JWT em
  `localStorage`, `innerHTML`, `npm audit`)
- **`standards.md`**: regra de idioma dividida — identificadores em inglês, prosa
  (comentários, testes, commits) em português; gaps documentados inline (CI não roda
  lint/test, sem Husky, sem semantic-release, sem template de PR)
- **`commit-msg` skill**: reescrita para gerar mensagens em português
- **`settings.json`**: libera `git commit *` no allow (a skill `commit-msg` comita
  direto); remove permissões/hook mortos de `./mvnw`/`.java`

## Como testar

- `npm test` — os 115 specs existentes continuam passando (nenhum código de app foi
  tocado, só `.claude/` e `CLAUDE.md`)
- Rodar `/context` numa sessão do Claude Code e conferir se os arquivos carregam sem erro

## Checklist

- [ ] Testes adicionados: não aplicável — mudança é só documentação/config para IA
- [x] Docs atualizadas: é o próprio conteúdo do PR
- [ ] Breaking changes: não