### PR TITLE
fix(forms): reject whitespace-only name in category and person forms

### DIFF
--- a/src/app/features/categories/categories.component.spec.ts
+++ b/src/app/features/categories/categories.component.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { CategoriesComponent } from './categories.component';
+
+describe('CategoriesComponent', () => {
+  let component: CategoriesComponent;
+  let fixture: ComponentFixture<CategoriesComponent>;
+  let http: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CategoriesComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CategoriesComponent);
+    component = fixture.componentInstance;
+    http = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    http.expectOne('/api/categories').flush([]);
+  });
+
+  afterEach(() => http.verify());
+
+  it('marca inválido quando o nome é só espaços em branco', () => {
+    component.categoryForm.name().value.set('   ');
+    expect(component.categoryForm.name().valid()).toBeFalse();
+  });
+
+  it('mantém válido com um nome de verdade', () => {
+    component.categoryForm.name().value.set('Academia');
+    expect(component.categoryForm.name().valid()).toBeTrue();
+  });
+});

--- a/src/app/features/categories/categories.component.ts
+++ b/src/app/features/categories/categories.component.ts
@@ -4,6 +4,7 @@ import { form, FormField, required, minLength } from '@angular/forms/signals';
 import { CategoryService } from '../../core/services/category.service';
 import { ToastService } from '../../shared/services/toast.service';
 import { Category } from '../../core/models';
+import { notBlank } from '../../shared/validators/not-blank.validator';
 
 type FilterType = 'TODOS' | 'RECEITA' | 'DESPESA';
 
@@ -35,6 +36,7 @@ export class CategoriesComponent implements OnInit {
   readonly categoryForm = form(this.model, (f) => {
     required(f.name, { message: 'Nome obrigatório' });
     minLength(f.name, 2, { message: 'Mínimo 2 caracteres' });
+    notBlank(f.name, { message: 'Nome não pode ser só espaços' });
   });
 
   // Validade geral do form

--- a/src/app/features/persons/persons.component.spec.ts
+++ b/src/app/features/persons/persons.component.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { PersonsComponent } from './persons.component';
+
+describe('PersonsComponent', () => {
+  let component: PersonsComponent;
+  let fixture: ComponentFixture<PersonsComponent>;
+  let http: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PersonsComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PersonsComponent);
+    component = fixture.componentInstance;
+    http = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    http.expectOne('/api/persons').flush([]);
+  });
+
+  afterEach(() => http.verify());
+
+  it('marca inválido quando o nome é só espaços em branco', () => {
+    component.personForm.name().value.set('   ');
+    expect(component.personForm.name().valid()).toBeFalse();
+  });
+
+  it('mantém válido com um nome de verdade', () => {
+    component.personForm.name().value.set('Bruno');
+    expect(component.personForm.name().valid()).toBeTrue();
+  });
+});

--- a/src/app/features/persons/persons.component.ts
+++ b/src/app/features/persons/persons.component.ts
@@ -4,6 +4,7 @@ import { form, FormField, required, minLength } from '@angular/forms/signals';
 import { PersonService } from '../../core/services/person.service';
 import { ToastService } from '../../shared/services/toast.service';
 import { Person } from '../../core/models';
+import { notBlank } from '../../shared/validators/not-blank.validator';
 
 @Component({
   selector: 'app-persons',
@@ -27,6 +28,7 @@ export class PersonsComponent implements OnInit {
   readonly personForm = form(this.model, (f) => {
     required(f.name, { message: 'Nome obrigatório' });
     minLength(f.name, 2, { message: 'Mínimo 2 caracteres' });
+    notBlank(f.name, { message: 'Nome não pode ser só espaços' });
   });
 
   readonly formValid = computed(() => this.personForm.name().valid());

--- a/src/app/shared/validators/not-blank.validator.ts
+++ b/src/app/shared/validators/not-blank.validator.ts
@@ -1,0 +1,9 @@
+import { pattern, PathKind, SchemaPath, SchemaPathRules } from '@angular/forms/signals';
+
+// Signal Forms `required()` só rejeita string vazia — "   " passa. Isso cobre o buraco.
+export function notBlank<TPathKind extends PathKind = PathKind.Root>(
+  path: SchemaPath<string, SchemaPathRules.Supported, TPathKind>,
+  config?: { message?: string },
+): void {
+  pattern(path, /\S/, { message: config?.message ?? 'Não pode conter só espaços em branco' });
+}


### PR DESCRIPTION
## Contexto
`categories.component.ts` e `persons.component.ts` usam o mesmo par `required()`+`minLength(2)` do Signal Forms no campo nome — nenhum dos dois faz trim, então `"   "` passa na validação do client e o botão "Salvar" fica habilitado; só o backend rejeita (400), depois do clique. Achado na auditoria ao vivo registrada em #12.

## Mudanças
- Novo `notBlank()` em `src/app/shared/validators/not-blank.validator.ts`, construído sobre `pattern()` do Signal Forms — mesmo estilo declarativo de `required`/`minLength`
- Aplicado em `categories.component.ts` e `persons.component.ts`, junto das validações já existentes
- Primeiros specs desses dois componentes (não existiam antes)

## Como testar
- Abrir "Nova Categoria"/"Nova Pessoa", digitar só espaços no nome → "Salvar" deve continuar desabilitado
- `npx ng test --include='**/categories.component.spec.ts' --include='**/persons.component.spec.ts'`

## Checklist
- [x] Testes adicionados
- [x] Sem mudança de comportamento além da nova validação
- [x] Breaking changes: não

Fecha #20.