### PR TITLE
fix(auth): don't logout on 401/403 from the login request itself

### DIFF
--- a/src/app/core/auth/auth.interceptor.spec.ts
+++ b/src/app/core/auth/auth.interceptor.spec.ts
@@ -113,4 +113,60 @@ describe('authInterceptor', () => {
 
     expect(authService.logout).toHaveBeenCalled();
   });
+
+  it('não deve chamar logout quando /auth/login retorna 401 (credencial errada, não sessão expirada)', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        provideRouter([{ path: 'login', component: class {} as any }]),
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    authService = TestBed.inject(AuthService);
+
+    spyOn(authService, 'logout');
+    let capturedError: unknown;
+    http.post('/api/auth/login', { username: 'admin', password: 'errada' }).subscribe({
+      error: (err) => (capturedError = err),
+    });
+
+    httpMock
+      .expectOne('/api/auth/login')
+      .flush({ message: 'Credenciais inválidas' }, { status: 401, statusText: 'Unauthorized' });
+
+    expect(authService.logout).not.toHaveBeenCalled();
+    expect(capturedError).toBeTruthy();
+  });
+
+  it('não deve chamar logout quando /auth/login retorna 403 (ex.: rejeição de CORS, não sessão expirada)', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        provideRouter([{ path: 'login', component: class {} as any }]),
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    authService = TestBed.inject(AuthService);
+
+    spyOn(authService, 'logout');
+    let capturedError: unknown;
+    http.post('/api/auth/login', { username: 'admin', password: '123456' }).subscribe({
+      error: (err) => (capturedError = err),
+    });
+
+    httpMock
+      .expectOne('/api/auth/login')
+      .flush({ message: 'Forbidden' }, { status: 403, statusText: 'Forbidden' });
+
+    expect(authService.logout).not.toHaveBeenCalled();
+    expect(capturedError).toBeTruthy();
+  });
 });

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -13,7 +13,13 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
     catchError((error: HttpErrorResponse) => {
       // backend só usa 401 pra credencial errada no login (não autenticado ainda);
       // token ausente/inválido/expirado nas rotas protegidas vem como 403 (Spring Security)
-      if (error.status === 401 || error.status === 403) {
+      //
+      // 401/403 vindo do próprio /auth/login não é sessão expirada — é falha de login
+      // (credencial errada, ou até um 403 de infra como rejeição de CORS). Chamar
+      // logout() aqui navega pra /login e recria o LoginComponent antes de ele
+      // conseguir mostrar a mensagem de erro pro usuário.
+      const isLoginRequest = req.url.includes('/auth/login');
+      if (!isLoginRequest && (error.status === 401 || error.status === 403)) {
         auth.logout();
       }
       return throwError(() => error);


### PR DESCRIPTION
## Contexto
`authInterceptor` chamava `auth.logout()` (que navega pra `/login`) pra qualquer 401/403, inclusive vindo do próprio `POST /auth/login`. Isso recria o `LoginComponent` antes de `errorMessage.set(...)` conseguir mostrar a mensagem — reproduzido ao vivo com um 403 (rejeição de CORS antes de validar credencial): a tela só voltava vazia, sem nenhum feedback. Achado/ampliado na auditoria registrada em #12.

## Mudanças
- `authInterceptor` não chama mais `logout()` quando a requisição que falhou é o próprio `/auth/login` — o erro continua propagando normalmente pro `LoginComponent` mostrar a mensagem
- 401/403 em qualquer outra rota (protegida) continua chamando `logout()` como antes — coberto pelos dois testes já existentes, que continuam passando sem alteração
- Dois novos testes em `auth.interceptor.spec.ts` cobrindo 401 e 403 vindos de `/auth/login`

## Como testar
- Tentar logar com senha errada → mensagem de erro aparece normalmente, sem o form resetar sozinho
- `npx ng test --include='**/auth.interceptor.spec.ts'`

## Checklist
- [x] Testes adicionados
- [x] Comportamento de logout em rotas protegidas não muda (testes existentes intactos)
- [x] Breaking changes: não

Fecha #16.