### PR TITLE
docs: document dev-first branch flow (PRs target dev, main is release-only)

### DIFF
--- a/.claude/rules/general-best-practices.md
+++ b/.claude/rules/general-best-practices.md
@@ -11,7 +11,9 @@ Aplica-se a todo o repositório, independente de linguagem ou stack.
 ## Git e commits
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`
 - Um commit = uma mudança lógica; evite commits "ajustes diversos"
-- Branch a partir de `main`/`develop` atualizada; nomeie como `feat/nome-da-feature` ou `fix/descricao-do-bug`
+- Branch a partir de `dev` atualizada (não `main` — `main` é só release); nomeie como `feat/nome-da-feature` ou `fix/descricao-do-bug`
+- PR sempre mira `dev`, nunca `main` diretamente — `main` só avança via PR de release de `dev` pra `main`
+- Quando um branch novo depende de verdade de outro ainda não mergeado, abra o PR em stack (`--base <branch-dependente>` em vez de `--base dev`) em vez de esperar o merge
 - Nunca commitar arquivos gerados (build, node_modules, target) — confira `.gitignore` antes de criar algo novo
 
 ## Tratamento de erros

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,12 +37,14 @@ Prettier (config embutida no `package.json`) + TypeScript strict.
   RxJS, Tailwind CSS v4 (PostCSS), ApexCharts/`ng-apexcharts`
 - **Testes**: Karma + Jasmine (`karma-coverage` instalado, sem threshold obrigatório)
 - **CI/CD**: GitHub Actions builda e publica a imagem Docker no push pra `main`
-  (`docker-publish.yml`) — não roda lint nem teste
+  (`docker-publish.yml`) — não roda lint nem teste. Deliberado: só `main` builda/deploya;
+  merge em `dev` não dispara nada
 - **Deploy**: Nginx servindo o build estático, Raspberry Pi 3B via Docker Compose
 
 ## Regras gerais
 
-- Nunca commitar direto na `main` — sempre via PR
+- Nunca commitar direto na `main` ou na `dev` — sempre via PR. PR mira `dev`; `main` só
+  se move via PR de release de `dev` pra `main`
 - Todo PR precisa passar lint + testes no CI antes do merge (hoje o CI só builda a imagem —
   gap conhecido, ver `.claude/rules/standards.md`)
 - Mensagens de commit no padrão Conventional Commits (`feat:`, `fix:`, `chore:`...)


### PR DESCRIPTION
## Contexto
Formaliza nos docs a introdução da branch `dev`: todo PR passa a mirar `dev`, `main` fica reservada pra release (é o que dispara `docker-publish.yml`/deploy no Pi).

## Mudanças
- `CLAUDE.md`/`general-best-practices.md`: PR mira `dev`; `main` só avança via PR de release
- Nota sobre stacking: branch dependente de outro ainda não mergeado usa `--base <branch>` em vez de `--base dev`

## Checklist
- [x] Só documentação, sem mudança de comportamento
- [x] Breaking changes: não