### PR TITLE
fix(transactions): sync month select with the model on every render

### DIFF
--- a/src/app/features/transactions/transaction-form/transaction-form.component.html
+++ b/src/app/features/transactions/transaction-form/transaction-form.component.html
@@ -78,14 +78,18 @@
           <div class="ledger-form-group" style="margin-bottom: 0;">
             <label class="ledger-label">Mês de referência *</label>
             <select
+              #monthSelect
               class="ledger-select"
               [value]="transactionForm.referenceMonth().value()"
-              (change)="transactionForm.referenceMonth().value.set(+$any($event.target).value)"
+              (change)="transactionForm.referenceMonth().value.set($any($event.target).value)"
             >
               @for (m of months; track m.value) {
                 <option [value]="m.value">{{ m.label }}</option>
               }
             </select>
+            @if (transactionForm.referenceMonth().touched() && transactionForm.referenceMonth().invalid()) {
+              <p class="ledger-error">{{ transactionForm.referenceMonth().errors()[0]?.message }}</p>
+            }
           </div>
           <div class="ledger-form-group" style="margin-bottom: 0;">
             <label class="ledger-label">Ano de referência *</label>

--- a/src/app/features/transactions/transaction-form/transaction-form.component.spec.ts
+++ b/src/app/features/transactions/transaction-form/transaction-form.component.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { provideRouter } from '@angular/router';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
 import { TransactionFormComponent } from './transaction-form.component';
+import { MonthYearService } from '../../../core/services/month-year.service';
 
 describe('TransactionFormComponent', () => {
   let component: TransactionFormComponent;
@@ -33,7 +34,7 @@ describe('TransactionFormComponent', () => {
         description: 'Aluguel',
         categoryId: 'cat-1',
         type: 'DESPESA',
-        referenceMonth: 3,
+        referenceMonth: '3',
         referenceYear: 2026,
         amountExpected: 1800,
         amountPaid: null,
@@ -48,7 +49,7 @@ describe('TransactionFormComponent', () => {
         description: 'Aluguel',
         categoryId: 'cat-1',
         type: 'DESPESA',
-        referenceMonth: 3,
+        referenceMonth: '3',
         referenceYear: 2026,
         amountExpected: 0,
         amountPaid: null,
@@ -63,7 +64,7 @@ describe('TransactionFormComponent', () => {
         description: '',
         categoryId: 'cat-1',
         type: 'DESPESA',
-        referenceMonth: 3,
+        referenceMonth: '3',
         referenceYear: 2026,
         amountExpected: 500,
         amountPaid: null,
@@ -97,6 +98,81 @@ describe('TransactionFormComponent', () => {
       component.setType('RECEITA');
       expect(component.transactionForm.type().value()).toBe('RECEITA');
       expect(component.transactionForm.categoryId().value()).toBe('');
+    });
+  });
+
+  // aque-web#18: o <select> de mês não refletia o valor real do model no DOM (mostrava
+  // sempre a primeira opção) — esses dois testes inspecionam o elemento renderizado,
+  // não só o model, porque foi exatamente aí que o bug vivia.
+  describe('sincronização do <select> de mês de referência', () => {
+    let http: HttpTestingController;
+    let monthYearService: MonthYearService;
+
+    function setupWithRoute(routeParams: Record<string, string> = {}): void {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [TransactionFormComponent],
+        providers: [
+          provideHttpClient(),
+          provideHttpClientTesting(),
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useValue: { snapshot: { paramMap: convertToParamMap(routeParams) } },
+          },
+        ],
+      });
+
+      monthYearService = TestBed.inject(MonthYearService);
+      monthYearService.setMonthYear(5, 2027);
+
+      fixture = TestBed.createComponent(TransactionFormComponent);
+      http = TestBed.inject(HttpTestingController);
+    }
+
+    afterEach(() => http.verify());
+
+    it('mostra o mês correto no select assim que a tela carrega, sem precisar tocar no campo', async () => {
+      setupWithRoute();
+      fixture.detectChanges();
+      http.expectOne((req) => req.url.includes('/api/categories')).flush([]);
+      // afterRenderEffect só roda depois que a view (incluindo as <option> do @for)
+      // termina de montar — precisa esperar estabilizar antes de checar o DOM
+      await fixture.whenStable();
+
+      // segundo <select> da tela: o primeiro é "Categoria"
+      const select: HTMLSelectElement = fixture.nativeElement.querySelectorAll('select')[1];
+      expect(select.value).toBe('5');
+    });
+
+    it('reflete o mês do lançamento carregado na edição, não o mês global atual', async () => {
+      setupWithRoute({ id: 'transacao-1' });
+      fixture.detectChanges();
+      http.expectOne((req) => req.url.includes('/api/categories')).flush([]);
+      await fixture.whenStable();
+
+      http.expectOne((req) => req.url.includes('/api/transactions')).flush([
+        {
+          id: 'transacao-1',
+          description: 'Aluguel',
+          category: { id: 'cat-1', name: 'Moradia', type: 'DESPESA', predefined: true },
+          type: 'DESPESA',
+          referenceMonth: 8,
+          referenceYear: 2026,
+          amountExpected: 1500,
+          amountPaid: null,
+          status: 'PENDENTE',
+          dueDate: null,
+          recurringId: null,
+          isOverride: false,
+        },
+      ]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // segundo <select> da tela: o primeiro é "Categoria"
+      const select: HTMLSelectElement = fixture.nativeElement.querySelectorAll('select')[1];
+      expect(select.value).toBe('8');
     });
   });
 });

--- a/src/app/features/transactions/transaction-form/transaction-form.component.ts
+++ b/src/app/features/transactions/transaction-form/transaction-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, computed, OnInit } from '@angular/core';
+import { Component, ElementRef, afterRenderEffect, inject, signal, computed, viewChild, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, ActivatedRoute } from '@angular/router';
 import { form, FormField, required, min } from '@angular/forms/signals';
@@ -12,7 +12,7 @@ interface TransactionModel {
   description: string;
   categoryId: string;
   type: 'RECEITA' | 'DESPESA';
-  referenceMonth: number;
+  referenceMonth: string;
   referenceYear: number;
   amountExpected: number;
   amountPaid: number | null;
@@ -62,7 +62,7 @@ export class TransactionFormComponent implements OnInit {
     description: '',
     categoryId: '',
     type: 'DESPESA',
-    referenceMonth: this.monthYear.month(),
+    referenceMonth: String(this.monthYear.month()),
     referenceYear: this.monthYear.year(),
     amountExpected: 0,
     amountPaid: null,
@@ -102,6 +102,23 @@ export class TransactionFormComponent implements OnInit {
     { value: 12, label: 'Dezembro' },
   ];
 
+  private readonly monthSelect = viewChild<ElementRef<HTMLSelectElement>>('monthSelect');
+
+  constructor() {
+    // [formField]/[value] num <select> nativo só sincroniza de forma confiável quando as
+    // <option> do @for já existem no momento do binding — falha (mostra a primeira opção)
+    // quando o valor é setado programaticamente depois (ex.: carregar um lançamento pra
+    // editar) sem que a lista de opções mude junto. afterRenderEffect roda garantidamente
+    // depois que a view (incluindo as <option>) já está montada, então sempre acerta.
+    afterRenderEffect(() => {
+      const month = this.transactionForm.referenceMonth().value();
+      const select = this.monthSelect()?.nativeElement;
+      if (select && select.value !== month) {
+        select.value = month;
+      }
+    });
+  }
+
   ngOnInit(): void {
     this.categoryService.getAll().subscribe({
       next: (data) => this.categories.set(data),
@@ -126,7 +143,7 @@ export class TransactionFormComponent implements OnInit {
             description: t.description,
             categoryId: t.category.id,
             type: t.type,
-            referenceMonth: t.referenceMonth,
+            referenceMonth: String(t.referenceMonth),
             referenceYear: t.referenceYear,
             amountExpected: t.amountExpected,
             amountPaid: t.amountPaid,
@@ -165,7 +182,7 @@ export class TransactionFormComponent implements OnInit {
       description: data.description,
       categoryId: data.categoryId,
       type: data.type,
-      referenceMonth: data.referenceMonth,
+      referenceMonth: Number(data.referenceMonth),
       referenceYear: data.referenceYear,
       amountExpected: data.amountExpected,
       amountPaid,


### PR DESCRIPTION
## Contexto
Achado grave na auditoria ao vivo (#12): o `<select>` de "Mês de referência" mostra "Janeiro" no primeiro render independente do mês real, mas salva no mês correto por baixo — confirmado direto no Postgres (tela mostrava "Janeiro", salvou com `reference_month=9`). Causa raiz: o binding manual `[value]`/`(change)` (necessário porque o campo é number e `[formField]` só lida com `<select>` como string) só aplica o valor antes das `<option>` do `@for` estarem garantidamente montadas.

## Mudanças
- Trocado o binding manual por `afterRenderEffect` + template ref, que roda depois que a view (incluindo as `<option>`) já está montada — corrige tanto o primeiro render quanto atualizações posteriores do model (ex.: carregar um lançamento existente pra editar, cenário onde `[formField]` sozinho não resolveu — seu mecanismo de recuperação via `MutationObserver` só re-dispara se a lista de opções mutar, e `months` é estática)
- `referenceMonth` no model do componente passa de `number` pra `string` (nativo de `<select>`), convertido de volta com `Number()` só na montagem do payload

## Como testar
- Abrir "Novo Lançamento" com o mês global em qualquer mês diferente de janeiro → o select já deve mostrar o mês certo sem precisar tocar nele
- Editar um lançamento existente de um mês diferente do mês global atual → o select deve refletir o mês do lançamento carregado

## Checklist
- [x] Testes adicionados (inspecionam o DOM renderizado, não só o model — é onde o bug vivia)
- [x] Suíte completa verde (123/123)
- [x] Breaking changes: não

Closes #18.
