### PR TITLE
feat(split): adapt split screen to versioned always-on split rule

### DIFF
--- a/docs/specs/17-adapt-split-screen-to-versioned-rule.md
+++ b/docs/specs/17-adapt-split-screen-to-versioned-rule.md
@@ -1,0 +1,41 @@
+# Adaptar tela de split à SplitRule onipresente/versionada
+
+- **Issue:** #17 — https://github.com/BrininhoBru/aque-web/issues/17
+- **Status:** Draft
+- **Repo:** BrininhoBru/aque-web
+
+## Problema
+
+`split.component.ts` e `split.service.ts` hoje tratam a regra de divisão como algo por mês: `SplitService.getByMonth`/`save` chamam `GET/PUT /split/{year}/{month}`, e o componente recarrega a configuração inteira (`loadSplit`) toda vez que `monthYear.selected()` muda (`effect()` no construtor). A issue companheira aque-backend#21 (`docs/specs/21-splitrule-versioned-by-effective-date.md`) redesenha `SplitRule` para ser uma configuração única e onipresente, versionada por vigência — a tela precisa parar de assumir "uma regra por mês" tanto na leitura quanto na gravação.
+
+## Escopo
+
+**Dentro:**
+- `SplitService`: parar de tratar a config como "por mês" — a leitura/gravação da regra passa a usar o(s) endpoint(s) que aque-backend#21 expuser para a versão vigente (mesma URL `/split/{year}/{month}` reaproveitada com semântica nova, ou uma nova rota — acompanhar a decisão de API tomada na implementação do backend).
+- `split.component.ts`: `loadSplit` deixa de ser recarregado a cada troca de mês/ano — a configuração (`items`, percentuais) só é buscada uma vez (ou quando o usuário navega para a tela), não a cada clique em `‹`/`›` do header.
+- `loadExpenses`/`totalExpenseExpected` continuam reagindo à troca de mês/ano normalmente — o valor calculado por pessoa ainda depende do total de despesas do mês selecionado (isso não muda com o redesenho).
+- `save()`: ao salvar, deixa claro para o usuário (cópia/mensagem) que a mudança vale a partir do mês atual em diante, não retroativamente — evitar a impressão de que está editando "o mês que está sendo visualizado" quando esse mês é passado.
+- Atualizar/remover o teste de precisão de float do split (issue #14) considerando o novo fluxo, se o ponto de validação mudar de lugar.
+
+**Fora:**
+- Tela ou componente de histórico de versões (fora de escopo também no backend, aque-backend#21).
+- Mudanças no modelo de dados — tratadas em aque-backend#21.
+- Qualquer UI para agendar vigência futura ou editar uma versão passada (o backend não vai suportar isso nesta entrega).
+
+## Abordagem
+
+`MonthYearService`/`monthYear.selected()` continua sendo a fonte do mês exibido no dashboard e em `totalExpenseExpected`, mas o `effect()` do construtor de `SplitComponent` deixa de chamar `loadSplit` a cada mudança — separar em dois efeitos (ou um efeito com early-return): um que sempre roda `loadExpenses(year, month)` ao trocar de mês, e a carga da regra (`loadSplit`) rodando só em `ngOnInit` (ou ao entrar na tela), já que a regra não varia mais com a navegação de mês. Se o usuário estiver vendo um mês passado, o formulário de edição deve deixar claro (texto de apoio) que salvar altera a vigência atual, não o mês em tela — evita o usuário achar que está reescrevendo o split de um mês fechado.
+
+`SplitService.getByMonth`/`save` mantêm a assinatura por enquanto (compatibilidade com a API atual do backend) até aque-backend#21 definir a forma final do endpoint; ajustar a chamada quando esse contrato for fechado — não vale a pena adivinhar a URL aqui antes do backend decidir.
+
+## Critério de aceite
+
+- [ ] Trocar de mês/ano na tela de split não dispara uma nova busca da configuração de divisão (só do valor total de despesas).
+- [ ] A configuração de split (pessoas e percentuais) é carregada uma vez ao entrar na tela, refletindo a versão vigente no momento.
+- [ ] Salvar uma edição atualiza a regra vigente a partir de agora, sem exigir que o usuário esteja no mês atual selecionado no header para poder editar.
+- [ ] Ao visualizar um mês passado, a tela deixa claro (via texto/aviso) que a edição não altera o histórico daquele mês.
+- [ ] Teste de `split.component.ts` cobrindo: carregar a tela não dispara reload da regra ao trocar de mês; salvar chama o service uma vez com os dados esperados.
+
+## Questões em aberto
+
+Nenhuma no momento — depende da forma final da API definida durante a implementação de aque-backend#21; se o contrato exigir mudança de UX (ex.: campo de vigência visível), reabrir discussão antes de fechar o PR desta tela.

--- a/src/app/core/models/index.ts
+++ b/src/app/core/models/index.ts
@@ -42,8 +42,7 @@ export interface SplitRuleItem {
 }
 
 export interface SplitRule {
-  year: number;
-  month: number;
+  effectiveFrom: string;
   items: SplitRuleItem[];
 }
 

--- a/src/app/core/services/split.service.spec.ts
+++ b/src/app/core/services/split.service.spec.ts
@@ -9,8 +9,7 @@ describe('SplitService', () => {
   let http: HttpTestingController;
 
   const rule: SplitRule = {
-    year: 2026,
-    month: 3,
+    effectiveFrom: '2026-03-01',
     items: [{ person: { id: 'p1', name: 'Eu' }, percentage: 100 }],
   };
 
@@ -29,7 +28,7 @@ describe('SplitService', () => {
   });
 
   describe('getByMonth()', () => {
-    it('deve buscar a regra do mês/ano informado', () => {
+    it('deve buscar a regra vigente no mês/ano informado', () => {
       service.getByMonth(2026, 3).subscribe((res) => expect(res).toEqual(rule));
 
       const req = http.expectOne('/api/split/2026/3');
@@ -39,12 +38,12 @@ describe('SplitService', () => {
   });
 
   describe('save()', () => {
-    it('deve enviar PUT com o payload da divisão', () => {
+    it('deve enviar PUT sem mês/ano com o payload da divisão', () => {
       const payload: SplitPayload = { items: [{ personId: 'p1', percentage: 100 }] };
 
-      service.save(2026, 3, payload).subscribe((res) => expect(res).toEqual(rule));
+      service.save(payload).subscribe((res) => expect(res).toEqual(rule));
 
-      const req = http.expectOne('/api/split/2026/3');
+      const req = http.expectOne('/api/split');
       expect(req.request.method).toBe('PUT');
       expect(req.request.body).toEqual(payload);
       req.flush(rule);

--- a/src/app/core/services/split.service.ts
+++ b/src/app/core/services/split.service.ts
@@ -17,7 +17,7 @@ export class SplitService {
     return this.http.get<SplitRule>(`${this.base}/${year}/${month}`);
   }
 
-  save(year: number, month: number, data: SplitPayload): Observable<SplitRule> {
-    return this.http.put<SplitRule>(`${this.base}/${year}/${month}`, data);
+  save(data: SplitPayload): Observable<SplitRule> {
+    return this.http.put<SplitRule>(this.base, data);
   }
 }

--- a/src/app/features/split/split.component.html
+++ b/src/app/features/split/split.component.html
@@ -16,8 +16,11 @@
       <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/>
     </svg>
     <p class="text-body-sm" style="color: var(--color-ledger-pending)">
-      Esta regra se aplica sobre o <strong>total de despesas previstas</strong> do mês.
-      Alterar os percentuais não afeta meses anteriores.
+      Esta regra se aplica sobre o <strong>total de despesas previstas</strong> de cada mês.
+      Alterar os percentuais vale a partir do mês atual em diante — não reescreve meses já fechados.
+      @if (isViewingPastMonth()) {
+        Você está visualizando um mês passado: salvar não altera o split <strong>daquele</strong> mês, só a partir de agora.
+      }
     </p>
   </div>
 

--- a/src/app/features/split/split.component.spec.ts
+++ b/src/app/features/split/split.component.spec.ts
@@ -3,6 +3,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { SplitComponent } from './split.component';
+import { MonthYearService } from '../../core/services/month-year.service';
 
 describe('SplitComponent', () => {
   let component: SplitComponent;
@@ -106,9 +107,10 @@ describe('SplitComponent', () => {
 
       component.save();
 
-      const req = httpMock.expectOne((r) => r.method === 'PUT' && r.url.startsWith('/api/split/'));
+      const req = httpMock.expectOne('/api/split');
+      expect(req.request.method).toBe('PUT');
       expect(req.request.body.items).toEqual([{ personId: '1', percentage: 100 }]);
-      req.flush({ year: 2026, month: 1, items: [] });
+      req.flush({ effectiveFrom: '2026-01-01', items: [] });
     });
 
     it('não deve salvar quando a soma dos percentuais não é 100%', () => {
@@ -118,6 +120,70 @@ describe('SplitComponent', () => {
 
       expect(component.saving()).toBeFalse();
       httpMock.expectNone((r) => r.method === 'PUT');
+    });
+  });
+
+  describe('reload ao trocar mês/ano', () => {
+    function flushInitialLoad(): void {
+      fixture.detectChanges();
+      httpMock.expectOne('/api/persons').flush([]);
+      httpMock.expectOne((r) => r.url.startsWith('/api/split/')).flush({
+        effectiveFrom: '2026-01-01',
+        items: [],
+      });
+      httpMock.expectOne((r) => r.url.startsWith('/api/dashboard/summary/')).flush({
+        totalIncomeExpected: 0,
+        totalIncomePaid: 0,
+        totalExpenseExpected: 0,
+        totalExpensePaid: 0,
+        balanceExpected: 0,
+        balancePaid: 0,
+        totalIncomePending: 0,
+        totalExpensePending: 0,
+        totalOverdueAmount: 0,
+        totalOverdueCount: 0,
+      });
+    }
+
+    it('deve buscar a regra de split apenas uma vez, mesmo trocando o mês selecionado', () => {
+      flushInitialLoad();
+
+      TestBed.inject(MonthYearService).nextMonth();
+      fixture.detectChanges();
+
+      // só o total de despesas acompanha a troca de mês
+      httpMock.expectOne((r) => r.url.startsWith('/api/dashboard/summary/')).flush({
+        totalIncomeExpected: 0,
+        totalIncomePaid: 0,
+        totalExpenseExpected: 0,
+        totalExpensePaid: 0,
+        balanceExpected: 0,
+        balancePaid: 0,
+        totalIncomePending: 0,
+        totalExpensePending: 0,
+        totalOverdueAmount: 0,
+        totalOverdueCount: 0,
+      });
+      const noSplitRequest = httpMock.match((r) => r.url.startsWith('/api/split/'));
+      expect(noSplitRequest.length).toBe(0);
+    });
+  });
+
+  describe('isViewingPastMonth()', () => {
+    it('deve ser true quando o mês/ano selecionado já passou', () => {
+      TestBed.inject(MonthYearService).setMonthYear(1, 2000);
+      expect(component.isViewingPastMonth()).toBeTrue();
+    });
+
+    it('deve ser false quando o mês/ano selecionado é o atual', () => {
+      const now = new Date();
+      TestBed.inject(MonthYearService).setMonthYear(now.getMonth() + 1, now.getFullYear());
+      expect(component.isViewingPastMonth()).toBeFalse();
+    });
+
+    it('deve ser false quando o mês/ano selecionado é futuro', () => {
+      TestBed.inject(MonthYearService).setMonthYear(1, 2999);
+      expect(component.isViewingPastMonth()).toBeFalse();
     });
   });
 });

--- a/src/app/features/split/split.component.ts
+++ b/src/app/features/split/split.component.ts
@@ -70,6 +70,15 @@ export class SplitComponent implements OnInit {
   readonly totalValid = computed(() => this.totalPercentage() === 100);
   readonly totalDiff = computed(() => 100 - this.totalPercentage());
 
+  // A regra é onipresente (não varia por mês) — só o mês atual pode ser editado
+  // "a partir de agora"; visualizar um mês passado precisa deixar isso claro na tela
+  readonly isViewingPastMonth = computed(() => {
+    const { month, year } = this.monthYear.selected();
+    const now = new Date();
+    return year < now.getFullYear() ||
+      (year === now.getFullYear() && month < now.getMonth() + 1);
+  });
+
   // Valores calculados por pessoa com base no total de despesas
   readonly calculatedItems = computed(() =>
     this.items().map((i) => ({
@@ -79,10 +88,9 @@ export class SplitComponent implements OnInit {
   );
 
   constructor() {
-    // Recarrega ao mudar mês/ano global
+    // A regra não varia por mês — só o total de despesas exibido acompanha a navegação
     effect(() => {
       const { month, year } = this.monthYear.selected();
-      this.loadSplit(year, month);
       this.loadExpenses(year, month);
     });
   }
@@ -91,11 +99,13 @@ export class SplitComponent implements OnInit {
     this.personService.getAll().subscribe({
       next: (data) => this.persons.set(data),
     });
+    this.loadSplit();
   }
 
-  loadSplit(year: number, month: number): void {
+  loadSplit(): void {
     this.loading.set(true);
-    this.splitService.getByMonth(year, month).subscribe({
+    const now = new Date();
+    this.splitService.getByMonth(now.getFullYear(), now.getMonth() + 1).subscribe({
       next: (rule) => {
         // Carrega percentuais existentes
         this.items.set(
@@ -157,8 +167,6 @@ export class SplitComponent implements OnInit {
     if (!this.totalValid() || this.saving()) return;
     this.saving.set(true);
 
-    const { year, month } = this.monthYear.selected();
-
     const payload: SplitPayload = {
       // backend rejeita percentage <= 0 (regra: só quem tem participação real entra na divisão)
       items: this.items()
@@ -169,7 +177,7 @@ export class SplitComponent implements OnInit {
         })),
     };
 
-    this.splitService.save(year, month, payload).subscribe({
+    this.splitService.save(payload).subscribe({
       next: () => {
         this.toast.success('Regra de divisão salva!');
         this.saving.set(false);


### PR DESCRIPTION
## Contexto

Fecha #17. O backend (aque-backend#21, PR #29 já mergeado em dev) trocou `SplitRule` de
"uma linha por mês" para uma configuração única, onipresente, versionada por
`effectiveFrom`: `PUT /split` (sem mês na URL) sempre cria uma nova versão vigente a
partir do mês atual; `GET /split/{year}/{month}` resolve "a versão vigente naquele mês".
A tela ainda assumia o modelo antigo — recarregava a regra inteira a cada troca de mês no
header e salvava contra `PUT /split/{year}/{month}`.

## Mudanças

- `SplitRule`: `year`/`month` → `effectiveFrom` (ISO date)
- `SplitService.save()`: perde `year`/`month`, chama `PUT /split`
- `split.component.ts`: `loadSplit()` sai do `effect()` reativo ao mês selecionado e vai
  para `ngOnInit` (roda uma única vez, usando a data de hoje); o `effect()` do construtor
  passa a só atualizar o total de despesas exibido ao trocar de mês
- Novo `isViewingPastMonth()` + aviso na tela: deixa claro que salvar vale a partir do mês
  atual em diante, não reescreve o mês em visualização quando esse mês já passou

## Como testar

- `npm test` — suíte inteira verde (127 testes)
- Manual (aque-backend rodando com o PR #29 mergeado): abrir `/split`, trocar de mês no
  header repetidas vezes e confirmar via Network tab que só a chamada de
  `dashboard/summary` dispara, não `GET /split/...`; salvar uma regra; navegar pra um mês
  passado e confirmar que o aviso extra aparece no banner

## Checklist

- [x] Testes adicionados (cobrindo: sem reload do split ao trocar mês, `isViewingPastMonth`)
- [x] Docs atualizadas (`docs/specs/17-adapt-split-screen-to-versioned-rule.md`)
- [x] Breaking changes: não (o app já dependia do PR #29 do backend, que já é a versão
      vigente em `dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZUESsfDzwyhGpCoNUU8xA