### PR TITLE
fix(split): round percentage sum to avoid floating-point rejection

### DIFF
--- a/src/app/features/split/split.component.spec.ts
+++ b/src/app/features/split/split.component.spec.ts
@@ -38,6 +38,25 @@ describe('SplitComponent', () => {
       component['items'].set([]);
       expect(component.totalPercentage()).toBe(0);
     });
+
+    it('deve considerar válida uma soma que bate 100 em decimal mas sofre ruído de ponto flutuante', () => {
+      component['items'].set([
+        { person: { id: '1', name: 'A' }, percentage: 5.95 },
+        { person: { id: '2', name: 'B' }, percentage: 7.41 },
+        { person: { id: '3', name: 'C' }, percentage: 8.04 },
+        { person: { id: '4', name: 'D' }, percentage: 5.82 },
+        { person: { id: '5', name: 'E' }, percentage: 4.79 },
+        { person: { id: '6', name: 'F' }, percentage: 8.96 },
+        { person: { id: '7', name: 'G' }, percentage: 4.25 },
+        { person: { id: '8', name: 'H' }, percentage: 10.9 },
+        { person: { id: '9', name: 'I' }, percentage: 6.29 },
+        { person: { id: '10', name: 'J' }, percentage: 11.79 },
+        { person: { id: '11', name: 'K' }, percentage: 7.32 },
+        { person: { id: '12', name: 'L' }, percentage: 18.48 },
+      ]);
+      expect(component.totalPercentage()).toBe(100);
+      expect(component.totalValid()).toBeTrue();
+    });
   });
 
   describe('totalValid()', () => {

--- a/src/app/features/split/split.component.ts
+++ b/src/app/features/split/split.component.ts
@@ -62,10 +62,13 @@ export class SplitComponent implements OnInit {
   readonly saving = signal(false);
   readonly totalExpenseExpected = signal<number>(0);
 
-  // Soma total dos percentuais em tempo real
-  readonly totalPercentage = computed(() =>
-    this.items().reduce((acc, i) => acc + (i.percentage || 0), 0),
-  );
+  // Soma total dos percentuais em tempo real — arredonda pra 2 casas decimais (mesma
+  // escala dos inputs) pra não deixar ruído de ponto flutuante rejeitar uma soma que já
+  // bate 100 em decimal (ex.: vários percentuais de 2 casas podem somar 99.99999999999999)
+  readonly totalPercentage = computed(() => {
+    const sum = this.items().reduce((acc, i) => acc + (i.percentage || 0), 0);
+    return Math.round(sum * 100) / 100;
+  });
 
   readonly totalValid = computed(() => this.totalPercentage() === 100);
   readonly totalDiff = computed(() => 100 - this.totalPercentage());


### PR DESCRIPTION
## Contexto

Closes #14. `totalValid` compara `totalPercentage() === 100` após somar percentuais via
`parseFloat`. Vários percentuais de 2 casas decimais podem somar
`99.99999999999999`/`100.00000000000001` em ponto flutuante binário mesmo quando a soma
real em decimal é exatamente 100 — bloqueando o botão "Salvar" pra um split que o backend
(`BigDecimal.compareTo`) aceitaria. Reproduzido com valores aleatórios de 2 casas
decimais somando 12 pessoas (ex.:
`5.95+7.41+8.04+5.82+4.79+8.96+4.25+10.90+6.29+11.79+7.32+18.48 = 99.99999999999999`).

## Mudanças

- `totalPercentage()` arredonda a soma pra 2 casas decimais antes de retornar — mesma
  escala usada nos inputs de percentual, elimina o ruído de representação binária sem
  mudar a semântica da validação
- `totalValid`/`totalDiff` já derivam de `totalPercentage()`, corrigidos pela mesma
  mudança

## Como testar

- `npx ng test --include='**/split.component.spec.ts'`
- Preencher um split com percentuais de 2 casas decimais que somem 100 (ex.: os do teste
  novo) → "Salvar" não deve travar por diferença de ponto flutuante

## Checklist

- [x] Teste adicionado reproduzindo o cenário de ponto flutuante (red confirmado antes
      do fix: `Expected 99.99999999999999 to be 100`)
- [x] Suíte completa verde (176/176)
- [x] Breaking changes: não

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZUESsfDzwyhGpCoNUU8xA