### PR TITLE
fix(dashboard,transactions,split): duplicate split request and month-navigation race condition

### DIFF
--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -63,20 +63,12 @@ describe('DashboardComponent', () => {
   });
 
   describe('load() — mês sem regra de divisão configurada', () => {
-    it('mantém summary/byCategory/evolution e marca splitError quando split retorna 404', () => {
+    it('mantém summary/byCategory/evolution e marca splitError quando split retorna 404, sem duplicar nenhuma request', () => {
       const { month, year } = component.monthYear.selected();
       const base = '/api/dashboard';
 
-      // 1ª rodada: forkJoin dos 4 endpoints, disparada pelo effect() do construtor
-      httpMock.expectOne(`${base}/summary/${year}/${month}`).flush(summary({}));
-      httpMock.expectOne(`${base}/by-category/${year}/${month}`).flush([]);
-      httpMock.expectOne(`${base}/evolution/${year}`).flush([]);
-      httpMock
-        .expectOne(`${base}/split/${year}/${month}`)
-        .flush({ message: 'not found' }, { status: 404, statusText: 'Not Found' });
-
-      // 2ª rodada: loadPartial() repete os 3 primeiros e busca o split à parte
-      // (é exatamente a duplicidade de requisições reportada no levantamento)
+      // forkJoin dos 4 endpoints, disparada pelo effect() do construtor — split falhando
+      // (404) não pode mais derrubar o forkJoin inteiro nem disparar uma 2ª rodada
       httpMock.expectOne(`${base}/summary/${year}/${month}`).flush(summary({}));
       httpMock.expectOne(`${base}/by-category/${year}/${month}`).flush([]);
       httpMock.expectOne(`${base}/evolution/${year}`).flush([]);
@@ -87,6 +79,41 @@ describe('DashboardComponent', () => {
       expect(component.split()).toBeNull();
       expect(component.splitError()).toBeTrue();
       expect(component.summary()).not.toBeNull();
+      expect(component.loading()).toBeFalse();
+      httpMock.verify();
+    });
+  });
+
+  describe('load() — race condition entre trocas rápidas de mês', () => {
+    it('mantém o resultado da carga mais recente, mesmo se a resposta antiga chegar depois', () => {
+      const { month, year } = component.monthYear.selected();
+      const base = '/api/dashboard';
+
+      // 1ª rodada (carga inicial do effect do construtor)
+      const req1 = httpMock.expectOne(`${base}/summary/${year}/${month}`);
+      httpMock.expectOne(`${base}/by-category/${year}/${month}`).flush([]);
+      httpMock.expectOne(`${base}/evolution/${year}`).flush([]);
+      httpMock
+        .expectOne(`${base}/split/${year}/${month}`)
+        .flush({ message: 'not found' }, { status: 404, statusText: 'Not Found' });
+
+      // usuário navega rápido pro mês seguinte antes da 1ª rodada responder
+      const nextMonth = month === 12 ? 1 : month + 1;
+      const nextYear = month === 12 ? year + 1 : year;
+      component.load(nextYear, nextMonth);
+
+      const req2 = httpMock.expectOne(`${base}/summary/${nextYear}/${nextMonth}`);
+      httpMock.expectOne(`${base}/by-category/${nextYear}/${nextMonth}`).flush([]);
+      httpMock.expectOne(`${base}/evolution/${nextYear}`).flush([]);
+      httpMock
+        .expectOne(`${base}/split/${nextYear}/${nextMonth}`)
+        .flush({ message: 'not found' }, { status: 404, statusText: 'Not Found' });
+
+      // resposta da 2ª (mais nova) chega primeiro, depois a da 1ª (obsoleta)
+      req2.flush(summary({ totalIncomeExpected: 999 }));
+      req1.flush(summary({ totalIncomeExpected: 1 }));
+
+      expect(component.summary()?.totalIncomeExpected).toBe(999);
     });
   });
 });

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -1,7 +1,8 @@
 import { Component, inject, signal, computed, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
-import { forkJoin } from 'rxjs';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import {
   NgApexchartsModule,
   ApexNonAxisChartSeries,
@@ -245,6 +246,8 @@ export class DashboardComponent {
     };
   });
 
+  private latestRequestId = 0;
+
   constructor() {
     effect(() => {
       const { month, year } = this.monthYear.selected();
@@ -253,6 +256,7 @@ export class DashboardComponent {
   }
 
   load(year: number, month: number): void {
+    const requestId = ++this.latestRequestId;
     this.loading.set(true);
     this.splitError.set(false);
 
@@ -260,42 +264,27 @@ export class DashboardComponent {
       summary: this.dashboardService.getSummary(year, month),
       byCategory: this.dashboardService.getByCategory(year, month),
       evolution: this.dashboardService.getEvolution(year),
-      split: this.dashboardService.getSplit(year, month),
+      // trata o próprio erro em vez de deixar derrubar o forkJoin inteiro — um mês sem
+      // split configurado (404) não pode invalidar summary/byCategory/evolution
+      split: this.dashboardService.getSplit(year, month).pipe(
+        catchError(() => {
+          this.splitError.set(true);
+          return of(null);
+        }),
+      ),
     }).subscribe({
       next: (data) => {
+        if (requestId !== this.latestRequestId) return; // resposta obsoleta, ignora
         this.summary.set(data.summary);
         this.byCategory.set(data.byCategory);
         this.evolution.set(data.evolution);
         this.split.set(data.split);
         this.loading.set(false);
       },
-      error: () => this.loadPartial(year, month),
-    });
-  }
-
-  private loadPartial(year: number, month: number): void {
-    forkJoin({
-      summary: this.dashboardService.getSummary(year, month),
-      byCategory: this.dashboardService.getByCategory(year, month),
-      evolution: this.dashboardService.getEvolution(year),
-    }).subscribe({
-      next: (data) => {
-        this.summary.set(data.summary);
-        this.byCategory.set(data.byCategory);
-        this.evolution.set(data.evolution);
-        this.loading.set(false);
-      },
       error: () => {
+        if (requestId !== this.latestRequestId) return;
         this.toast.error('Erro ao carregar dados do dashboard.');
         this.loading.set(false);
-      },
-    });
-
-    this.dashboardService.getSplit(year, month).subscribe({
-      next: (data) => this.split.set(data),
-      error: () => {
-        this.split.set(null);
-        this.splitError.set(true);
       },
     });
   }

--- a/src/app/features/split/split.component.spec.ts
+++ b/src/app/features/split/split.component.spec.ts
@@ -167,6 +167,51 @@ describe('SplitComponent', () => {
       const noSplitRequest = httpMock.match((r) => r.url.startsWith('/api/split/'));
       expect(noSplitRequest.length).toBe(0);
     });
+
+    it('mantém o total de despesas da carga mais recente, mesmo se a resposta antiga chegar depois', () => {
+      fixture.detectChanges();
+      httpMock.expectOne('/api/persons').flush([]);
+      httpMock.expectOne((r) => r.url.startsWith('/api/split/')).flush({
+        effectiveFrom: '2026-01-01',
+        items: [],
+      });
+
+      // requisição de despesas disparada pelo effect() do construtor — ainda não respondida
+      const req1 = httpMock.expectOne((r) => r.url.startsWith('/api/dashboard/summary/'));
+
+      component.loadExpenses(2026, 4);
+      const req2 = httpMock.expectOne(
+        (r) => r.url.startsWith('/api/dashboard/summary/') && r.url.endsWith('/2026/4'),
+      );
+
+      // resposta da 2ª (mais nova) chega primeiro, depois a da 1ª (obsoleta)
+      req2.flush({
+        totalIncomeExpected: 0,
+        totalIncomePaid: 0,
+        totalExpenseExpected: 999,
+        totalExpensePaid: 0,
+        balanceExpected: 0,
+        balancePaid: 0,
+        totalIncomePending: 0,
+        totalExpensePending: 0,
+        totalOverdueAmount: 0,
+        totalOverdueCount: 0,
+      });
+      req1.flush({
+        totalIncomeExpected: 0,
+        totalIncomePaid: 0,
+        totalExpenseExpected: 1,
+        totalExpensePaid: 0,
+        balanceExpected: 0,
+        balancePaid: 0,
+        totalIncomePending: 0,
+        totalExpensePending: 0,
+        totalOverdueAmount: 0,
+        totalOverdueCount: 0,
+      });
+
+      expect(component.totalExpenseExpected()).toBe(999);
+    });
   });
 
   describe('isViewingPastMonth()', () => {

--- a/src/app/features/split/split.component.ts
+++ b/src/app/features/split/split.component.ts
@@ -62,6 +62,8 @@ export class SplitComponent implements OnInit {
   readonly saving = signal(false);
   readonly totalExpenseExpected = signal<number>(0);
 
+  private latestExpensesRequestId = 0;
+
   // Soma total dos percentuais em tempo real
   readonly totalPercentage = computed(() =>
     this.items().reduce((acc, i) => acc + (i.percentage || 0), 0),
@@ -127,9 +129,16 @@ export class SplitComponent implements OnInit {
   }
 
   loadExpenses(year: number, month: number): void {
+    const requestId = ++this.latestExpensesRequestId;
     this.dashboardService.getSummary(year, month).subscribe({
-      next: (s) => this.totalExpenseExpected.set(s.totalExpenseExpected),
-      error: () => this.totalExpenseExpected.set(0),
+      next: (s) => {
+        if (requestId !== this.latestExpensesRequestId) return; // resposta obsoleta, ignora
+        this.totalExpenseExpected.set(s.totalExpenseExpected);
+      },
+      error: () => {
+        if (requestId !== this.latestExpensesRequestId) return;
+        this.totalExpenseExpected.set(0);
+      },
     });
   }
 

--- a/src/app/features/transactions/transactions.component.spec.ts
+++ b/src/app/features/transactions/transactions.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { TransactionsComponent } from './transactions.component';
 import { Transaction, Category } from '../../core/models';
@@ -29,6 +29,7 @@ function tx(overrides: Partial<Transaction>): Transaction {
 describe('TransactionsComponent', () => {
   let component: TransactionsComponent;
   let fixture: ComponentFixture<TransactionsComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -38,10 +39,37 @@ describe('TransactionsComponent', () => {
 
     fixture = TestBed.createComponent(TransactionsComponent);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   it('deve criar o componente', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('load() — race condition entre trocas rápidas de mês', () => {
+    it('mantém o resultado da carga mais recente, mesmo se a resposta antiga chegar depois', () => {
+      fixture.detectChanges(); // dispara o effect() do construtor (carga inicial)
+      const { month, year } = component.monthYear.selected();
+
+      const req1 = httpMock.expectOne(
+        (r) => r.params.get('month') === String(month) && r.params.get('year') === String(year),
+      );
+
+      const nextMonth = month === 12 ? 1 : month + 1;
+      const nextYear = month === 12 ? year + 1 : year;
+      component.load(nextMonth, nextYear);
+
+      const req2 = httpMock.expectOne(
+        (r) =>
+          r.params.get('month') === String(nextMonth) && r.params.get('year') === String(nextYear),
+      );
+
+      // resposta da 2ª (mais nova) chega primeiro, depois a da 1ª (obsoleta)
+      req2.flush([tx({ id: 'novo' })]);
+      req1.flush([tx({ id: 'antigo' })]);
+
+      expect(component.transactions().map((t) => t.id)).toEqual(['novo']);
+    });
   });
 
   describe('filtered()', () => {

--- a/src/app/features/transactions/transactions.component.ts
+++ b/src/app/features/transactions/transactions.component.ts
@@ -108,6 +108,8 @@ export class TransactionsComponent implements OnInit {
   readonly filterType = signal<FilterType>('TODOS');
   readonly filterStatus = signal<FilterStatus>('TODOS');
 
+  private latestRequestId = 0;
+
   // Recarrega ao mudar mês/ano global
   constructor() {
     effect(() => {
@@ -129,13 +131,18 @@ export class TransactionsComponent implements OnInit {
       year: year ?? y,
     };
 
+    const requestId = ++this.latestRequestId;
     this.loading.set(true);
     this.transactionService.getAll(filters).subscribe({
       next: (data) => {
+        if (requestId !== this.latestRequestId) return; // resposta obsoleta, ignora
         this.transactions.set(data);
         this.loading.set(false);
       },
-      error: () => this.loading.set(false),
+      error: () => {
+        if (requestId !== this.latestRequestId) return;
+        this.loading.set(false);
+      },
     });
   }
 


### PR DESCRIPTION
## Contexto

Closes #19, closes #15. Dois bugs distintos da auditoria (#12), investigados juntos por
morarem na mesma área (carregamento reativo a `monthYear.selected()`), mas com causas
raiz diferentes — daí dois commits.

## #19 — dashboard duplica a request de split

`dashboard.component.ts` (`load()`) usa `forkJoin` pros 4 endpoints. `forkJoin` falha
por inteiro se qualquer membro falhar — quando `getSplit` dá 404 (mês sem regra
configurada), o forkJoin inteiro caía no `error()`, que chamava `loadPartial()`.
`loadPartial()` repetia `summary`/`byCategory`/`evolution` (que já tinham funcionado) e
buscava `getSplit` de novo (que ia falhar de novo). Resultado: os 4 endpoints eram
chamados 2x toda vez que o split não estava configurado — só o de split era visível
porque o 404 dispara um toast de erro a cada vez.

**Fix**: `getSplit` trata o próprio erro (`catchError` → `null` + `splitError.set(true)`)
em vez de deixar derrubar o `forkJoin`. `loadPartial()` foi removido — não tinha mais
razão de existir.

## #15 — race condition entre navegação de mês e respostas fora de ordem

`transactions`, `split` e `dashboard` reagem a `monthYear.selected()` via `effect()` +
`subscribe()` direto, sem cancelar a subscription anterior. Os botões `‹`/`›` do header
não têm debounce — clicar rápido entre meses podia deixar uma resposta antiga (mais
lenta) sobrescrever a tela com dado do mês errado.

**Fix**: guarda de "id da requisição mais recente" nos três componentes — cada carga
captura um id: a resposta só é aplicada se ainda for a mais recente id em voo.

## Como testar

- `npx ng test --include='**/dashboard.component.spec.ts' --include='**/transactions.component.spec.ts' --include='**/split.component.spec.ts'`
- Manual: acessar o Dashboard de um mês sem split configurado → um único toast de erro,
  não dois (checar Network tab: cada endpoint chamado uma vez). Simular latência
  variável e clicar rápido em `‹`/`›` em transactions/split/dashboard → a tela sempre
  reflete o último mês selecionado.

## Checklist

- [x] Testes adicionados (duplicidade de request fixada + race condition por componente,
      simulando resolução fora de ordem)
- [x] Suíte completa verde (130/130)
- [x] Breaking changes: não

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZUESsfDzwyhGpCoNUU8xA