### PR TITLE
fix(transactions): validate reference year/amountPaid and surface isOverride

### DIFF
--- a/src/app/features/transactions/transaction-form/transaction-form.component.html
+++ b/src/app/features/transactions/transaction-form/transaction-form.component.html
@@ -134,6 +134,9 @@
                 >✕</button>
               }
             </div>
+            @if (transactionForm.amountPaid().touched() && transactionForm.amountPaid().invalid()) {
+              <p class="ledger-error">{{ transactionForm.amountPaid().errors()[0]?.message }}</p>
+            }
           </div>
         </div>
 

--- a/src/app/features/transactions/transaction-form/transaction-form.component.spec.ts
+++ b/src/app/features/transactions/transaction-form/transaction-form.component.spec.ts
@@ -73,6 +73,40 @@ describe('TransactionFormComponent', () => {
       fixture.detectChanges();
       expect(component.formValid()).toBeFalse();
     });
+
+    it('deve ser inválido quando o ano de referência está fora de uma faixa plausível', () => {
+      component['model'].set({
+        description: 'Aluguel',
+        categoryId: 'cat-1',
+        type: 'DESPESA',
+        referenceMonth: '3',
+        referenceYear: 0,
+        amountExpected: 500,
+        amountPaid: null,
+        dueDate: null,
+      });
+      fixture.detectChanges();
+      expect(component.formValid()).toBeFalse();
+
+      component['model'].update((m) => ({ ...m, referenceYear: 99999 }));
+      fixture.detectChanges();
+      expect(component.formValid()).toBeFalse();
+    });
+
+    it('deve ser inválido quando o valor pago é negativo', () => {
+      component['model'].set({
+        description: 'Aluguel',
+        categoryId: 'cat-1',
+        type: 'DESPESA',
+        referenceMonth: '3',
+        referenceYear: 2026,
+        amountExpected: 500,
+        amountPaid: -50,
+        dueDate: null,
+      });
+      fixture.detectChanges();
+      expect(component.formValid()).toBeFalse();
+    });
   });
 
   describe('statusLabel()', () => {

--- a/src/app/features/transactions/transaction-form/transaction-form.component.ts
+++ b/src/app/features/transactions/transaction-form/transaction-form.component.ts
@@ -1,12 +1,15 @@
 import { Component, ElementRef, afterRenderEffect, inject, signal, computed, viewChild, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, ActivatedRoute } from '@angular/router';
-import { form, FormField, required, min } from '@angular/forms/signals';
+import { form, FormField, required, min, max, validate } from '@angular/forms/signals';
 import { TransactionService, TransactionPayload } from '../../../core/services/transaction.service';
 import { CategoryService } from '../../../core/services/category.service';
 import { ToastService } from '../../../shared/services/toast.service';
 import { MonthYearService } from '../../../core/services/month-year.service';
 import { Category } from '../../../core/models';
+
+const MIN_TRANSACTION_YEAR = 2000;
+const MAX_TRANSACTION_YEAR = new Date().getFullYear() + 10;
 
 interface TransactionModel {
   description: string;
@@ -74,8 +77,20 @@ export class TransactionFormComponent implements OnInit {
     required(f.categoryId, { message: 'Categoria obrigatória' });
     required(f.referenceMonth, { message: 'Mês obrigatório' });
     required(f.referenceYear, { message: 'Ano obrigatório' });
+    min(f.referenceYear, MIN_TRANSACTION_YEAR, {
+      message: `Ano deve ser a partir de ${MIN_TRANSACTION_YEAR}`,
+    });
+    max(f.referenceYear, MAX_TRANSACTION_YEAR, {
+      message: `Ano não pode passar de ${MAX_TRANSACTION_YEAR}`,
+    });
     required(f.amountExpected, { message: 'Valor previsto obrigatório' });
     min(f.amountExpected, 0.01, { message: 'Valor previsto deve ser positivo' });
+    validate(f.amountPaid, ({ value }) => {
+      const v = value();
+      return v != null && v < 0
+        ? { kind: 'negative', message: 'Valor pago não pode ser negativo' }
+        : undefined;
+    });
   });
 
   readonly formValid = computed(
@@ -84,7 +99,8 @@ export class TransactionFormComponent implements OnInit {
       this.transactionForm.categoryId().valid() &&
       this.transactionForm.referenceMonth().valid() &&
       this.transactionForm.referenceYear().valid() &&
-      this.transactionForm.amountExpected().valid(),
+      this.transactionForm.amountExpected().valid() &&
+      this.transactionForm.amountPaid().valid(),
   );
 
   readonly months = [

--- a/src/app/features/transactions/transactions.component.html
+++ b/src/app/features/transactions/transactions.component.html
@@ -121,12 +121,19 @@
                             <path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
                           </svg>
                         }
+                        @if (t.recurringId && t.isOverride) {
+                          <svg width="11" height="11" fill="currentColor" viewBox="0 0 24 24" style="color: var(--color-ledger-ink-lt); flex-shrink: 0;" title="Editado manualmente">
+                            <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 000-1.41l-2.34-2.34a1 1 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
+                          </svg>
+                        }
                         <span class="font-medium truncate" [style.color]="t.status === 'PAGO' ? 'var(--color-ledger-ink-lt)' : 'var(--color-ledger-ink)'">
                           {{ t.description }}
                         </span>
                       </div>
                       @if (t.recurringId) {
-                        <p class="text-body-sm" style="color: var(--color-ledger-ink-lt)">↻ recorrente</p>
+                        <p class="text-body-sm" style="color: var(--color-ledger-ink-lt)">
+                          ↻ recorrente@if (t.isOverride) { · editado manualmente }
+                        </p>
                       }
                     </td>
                     <td class="text-body-sm" style="color: var(--color-ledger-ink-md)">{{ t.category.name }}</td>
@@ -197,6 +204,11 @@
                 @if (t.recurringId) {
                   <svg width="11" height="11" fill="currentColor" viewBox="0 0 24 24" class="tx-card-recurring-icon" title="Gerado por recorrente">
                     <path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
+                  </svg>
+                }
+                @if (t.recurringId && t.isOverride) {
+                  <svg width="11" height="11" fill="currentColor" viewBox="0 0 24 24" class="tx-card-recurring-icon" title="Editado manualmente">
+                    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 000-1.41l-2.34-2.34a1 1 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
                   </svg>
                 }
                 <span class="tx-card-title" [style.color]="t.status === 'PAGO' ? 'var(--color-ledger-ink-lt)' : 'var(--color-ledger-ink)'">

--- a/src/app/features/transactions/transactions.component.spec.ts
+++ b/src/app/features/transactions/transactions.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { TransactionsComponent } from './transactions.component';
 import { Transaction, Category } from '../../core/models';
@@ -116,6 +116,37 @@ describe('TransactionsComponent', () => {
 
     it('totalIncomePaid soma só receitas pagas', () => {
       expect(component.totalIncomePaid()).toBe(3000);
+    });
+  });
+
+  describe('indicador de isOverride', () => {
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+      httpMock = TestBed.inject(HttpTestingController);
+    });
+
+    it('aparece quando a instância gerada por recorrente foi editada manualmente', () => {
+      // dispara o effect() do construtor (load() inicial); só o flush aplica os dados
+      // no signal transactions — loading() fica true até a resposta chegar, e a
+      // tabela/cards ficam ocultos enquanto loading() for true
+      fixture.detectChanges();
+      httpMock
+        .expectOne((r) => r.url === '/api/transactions')
+        .flush([tx({ recurringId: 'r1', isOverride: true })]);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[title="Editado manualmente"]')).not.toBeNull();
+    });
+
+    it('não aparece quando a instância do recorrente não foi editada', () => {
+      fixture.detectChanges();
+      httpMock
+        .expectOne((r) => r.url === '/api/transactions')
+        .flush([tx({ recurringId: 'r1', isOverride: false })]);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[title="Editado manualmente"]')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Contexto

Closes #13. Três achados independentes da auditoria (#12), todos em
`transaction-form.component.ts` (e um na lista de lançamentos).

## Mudanças

- `referenceYear` ganha `min()`/`max()` (faixa [2000, ano atual + 10]) — antes só tinha
  `required()`, um ano absurdo (0, 99999) contaminava filtros e a agregação por ano do
  dashboard. Fix server-side (backend `@Min`/`@Max`) fica de fora, é responsabilidade do
  aque-backend
- `amountPaid` ganha um `validate()` customizado rejeitando valores negativos (mantendo
  `null` válido, já que o campo é opcional) — antes `save()` descartava um negativo
  silenciosamente (virava `null` sem nenhum aviso)
- `isOverride` (existia no model, nunca setado na tela) agora aparece como um pequeno
  indicador "editado manualmente" ao lado do já existente "↻ recorrente", na tabela
  desktop e nos cards mobile

## Como testar

- `npx ng test --include='**/transaction-form.component.spec.ts' --include='**/transactions.component.spec.ts'`
- Manual: tentar salvar um lançamento com ano 0 ou 99999 → bloqueado com mensagem clara;
  digitar um valor pago negativo → bloqueado com mensagem clara; editar manualmente uma
  instância gerada por recorrente → a lista deve mostrar o indicador de edição manual

## Checklist

- [x] Testes adicionados (faixa de ano, valor pago negativo, indicador de isOverride via
      inspeção do DOM renderizado)
- [x] Suíte completa verde
- [x] Breaking changes: não

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZUESsfDzwyhGpCoNUU8xA