### PR TITLE
feat(recurring): add due day field to recurring transaction form

### DIFF
--- a/docs/specs/26-recurring-due-day-field.md
+++ b/docs/specs/26-recurring-due-day-field.md
@@ -1,0 +1,70 @@
+# Campo "dia do vencimento" no formulário de recorrente
+
+- **Issue:** #26 — https://github.com/BrininhoBru/aque-web/issues/26
+- **Status:** Draft
+- **Repo:** BrininhoBru/aque-web
+
+## Problema
+
+`aque-backend#19` (PR #28) adicionou um campo opcional `dueDay` (1-31) no
+`RecurringTransaction`, usado pelo job de geração mensal pra calcular o `dueDate` das
+instâncias geradas (sem ele, continuam sem vencimento — mesmo comportamento de antes do
+campo existir). O formulário de "Novo Recorrente"/"Editar Recorrente"
+(`recurring.component.ts`/`.html`) ainda não tem como configurar isso, então nenhum
+recorrente criado pela UI consegue se beneficiar do indicador de "atrasados" do
+dashboard.
+
+## Escopo
+
+**Dentro:**
+- Campo numérico opcional "Dia do vencimento" no formulário (`recurring.component.html`),
+  ao lado dos campos já existentes (Descrição, Tipo, Categoria, Valor padrão)
+- `RecurringPayload` (`recurring.service.ts`) e `RecurringTransaction`
+  (`core/models/index.ts`) ganham `dueDay: number | null`
+- `openCreate()`/`openEdit()`/`save()` em `recurring.component.ts` passam a
+  ler/escrever esse campo no model, mesmo padrão dos campos já existentes
+
+**Fora:**
+- Qualquer validação além de "1 a 31" — o backend já valida isso
+  (`@Min`/`@Max` em `RecurringTransactionRequest`); o form só precisa não deixar
+  digitar fora da faixa (`type="number" min="1" max="31"` já é suficiente)
+- Retroagir `dueDay` em recorrentes já existentes — o campo fica vazio até o usuário
+  editar e preencher
+- Mudança na tela de Lançamentos ou no cálculo de "atrasados" do dashboard — isso já
+  existe no backend, só falta o dado chegar lá
+
+## Abordagem
+
+Segue exatamente o padrão dos campos numéricos opcionais já existentes no app (ex.:
+`amountPaid` em `transaction-form.component.html`, que usa `[formField]` com um input
+`type="number"` simples, sem os problemas de `<select>` que motivaram `aque-web#18` —
+`dueDay` é um `<input type="number">`, não um `<select>`, então não tem o mesmo risco de
+sincronização).
+
+**`recurring.service.ts`**: `RecurringPayload` ganha `dueDay?: number | null`.
+
+**`core/models/index.ts`**: `RecurringTransaction` ganha `dueDay: number | null`.
+
+**`recurring.component.ts`**: `model` inicial ganha `dueDay: null`; `openCreate()` reseta
+pra `null`; `openEdit()` carrega `r.dueDay ?? null`; `save()` já envia o objeto inteiro do
+model (não monta um payload campo a campo), então `dueDay` viaja junto sem mudança
+adicional.
+
+**`recurring.component.html`**: novo grupo de campo (mesmo estilo de
+`ledger-form-group` já usado), com `[formField]="recurringForm.dueDay"` (registrar a
+validação `min(1)`/`max(31)` no `form()` do componente, mesmo padrão de
+`min(f.defaultAmount, 0.01, ...)` já existente) — sem `required()`, já que é opcional.
+
+## Critério de aceite
+
+- [ ] Criar um recorrente sem preencher "Dia do vencimento" continua funcionando
+      exatamente como hoje (campo enviado como `null`/omitido)
+- [ ] Criar um recorrente com "Dia do vencimento" preenchido (ex.: 5) salva esse valor,
+      confirmável reabrindo "Editar" e vendo o campo preenchido
+- [ ] Editar um recorrente existente pra adicionar/alterar/limpar o "Dia do vencimento"
+      funciona
+- [ ] Digitar um valor fora de 1-31 é bloqueado no client (o backend já rejeita, mas o
+      form não deveria deixar chegar lá)
+- [ ] Gerar recorrentes (`POST /recurring/generate/{year}/{month}`) pra um recorrente
+      criado com `dueDay` configurado pela UI resulta numa transação com `dueDate`
+      preenchido (verificação ponta a ponta com o backend já implementado)

--- a/src/app/core/models/index.ts
+++ b/src/app/core/models/index.ts
@@ -32,6 +32,7 @@ export interface RecurringTransaction {
   type: 'RECEITA' | 'DESPESA';
   defaultAmount: number;
   active: boolean;
+  dueDay: number | null;
 }
 
 export interface SplitRuleItem {

--- a/src/app/core/services/recurring.service.spec.ts
+++ b/src/app/core/services/recurring.service.spec.ts
@@ -16,6 +16,7 @@ describe('RecurringService', () => {
     type: 'DESPESA',
     defaultAmount: 1500,
     active: true,
+    dueDay: null,
   };
 
   beforeEach(() => {
@@ -57,6 +58,7 @@ describe('RecurringService', () => {
         categoryId: 'c1',
         type: 'DESPESA',
         defaultAmount: 1500,
+        dueDay: null,
       };
 
       service.create(payload).subscribe((res) => expect(res).toEqual(recurring));

--- a/src/app/core/services/recurring.service.ts
+++ b/src/app/core/services/recurring.service.ts
@@ -9,6 +9,7 @@ export interface RecurringPayload {
   categoryId: string;
   type: 'RECEITA' | 'DESPESA';
   defaultAmount: number;
+  dueDay: number | null;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/features/recurring/recurring.component.html
+++ b/src/app/features/recurring/recurring.component.html
@@ -212,7 +212,7 @@
           }
         </div>
 
-        <div class="ledger-form-group" style="margin-bottom: 0;">
+        <div class="ledger-form-group">
           <label class="ledger-label">Valor padrão (R$)</label>
           <div class="ledger-input-group">
             <span class="ledger-input-group-prefix">R$</span>
@@ -220,6 +220,14 @@
           </div>
           @if (recurringForm.defaultAmount().touched() && recurringForm.defaultAmount().invalid()) {
             <p class="ledger-error">{{ recurringForm.defaultAmount().errors()[0]?.message }}</p>
+          }
+        </div>
+
+        <div class="ledger-form-group" style="margin-bottom: 0;">
+          <label class="ledger-label">Dia do vencimento (opcional)</label>
+          <input class="ledger-input" type="number" min="1" max="31" [formField]="recurringForm.dueDay" placeholder="Ex: 10" />
+          @if (recurringForm.dueDay().touched() && recurringForm.dueDay().invalid()) {
+            <p class="ledger-error">{{ recurringForm.dueDay().errors()[0]?.message }}</p>
           }
         </div>
       </form>

--- a/src/app/features/recurring/recurring.component.spec.ts
+++ b/src/app/features/recurring/recurring.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { RecurringComponent } from './recurring.component';
 import { RecurringTransaction, Category } from '../../core/models';
@@ -16,6 +16,7 @@ function recurring(overrides: Partial<RecurringTransaction>): RecurringTransacti
     type: 'DESPESA',
     defaultAmount: 1500,
     active: true,
+    dueDay: null,
     ...overrides,
   };
 }
@@ -23,6 +24,7 @@ function recurring(overrides: Partial<RecurringTransaction>): RecurringTransacti
 describe('RecurringComponent', () => {
   let component: RecurringComponent;
   let fixture: ComponentFixture<RecurringComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -32,6 +34,7 @@ describe('RecurringComponent', () => {
 
     fixture = TestBed.createComponent(RecurringComponent);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   it('deve criar o componente', () => {
@@ -114,6 +117,51 @@ describe('RecurringComponent', () => {
 
       expect(component.editingId()).toBeNull();
       expect(component.recurringForm.description().value()).toBe('');
+    });
+  });
+
+  describe('dueDay', () => {
+    it('openEdit() carrega o dueDay do recorrente quando presente', () => {
+      component.openEdit(recurring({ id: '42', dueDay: 15 }));
+      expect(component.recurringForm.dueDay().value()).toBe(15);
+    });
+
+    it('openEdit() carrega null quando o recorrente não tem dueDay', () => {
+      component.openEdit(recurring({ id: '42', dueDay: null }));
+      expect(component.recurringForm.dueDay().value()).toBeNull();
+    });
+
+    it('openCreate() reseta o dueDay para null', () => {
+      component.openEdit(recurring({ id: '42', dueDay: 15 }));
+      component.openCreate();
+      expect(component.recurringForm.dueDay().value()).toBeNull();
+    });
+
+    it('rejeita valor fora de 1-31', () => {
+      component.recurringForm.description().value.set('Aluguel');
+      component.recurringForm.categoryId().value.set(despesaCategory.id);
+      component.recurringForm.defaultAmount().value.set(1500);
+      component.recurringForm.dueDay().value.set(32);
+      expect(component.formValid()).toBeFalse();
+
+      component.recurringForm.dueDay().value.set(0);
+      expect(component.formValid()).toBeFalse();
+
+      component.recurringForm.dueDay().value.set(15);
+      expect(component.formValid()).toBeTrue();
+    });
+
+    it('save() envia o dueDay no payload', () => {
+      component.recurringForm.description().value.set('Aluguel');
+      component.recurringForm.categoryId().value.set(despesaCategory.id);
+      component.recurringForm.defaultAmount().value.set(1500);
+      component.recurringForm.dueDay().value.set(5);
+
+      component.save();
+
+      const req = httpMock.expectOne('/api/recurring');
+      expect(req.request.body.dueDay).toBe(5);
+      req.flush(recurring({ dueDay: 5 }));
     });
   });
 });

--- a/src/app/features/recurring/recurring.component.ts
+++ b/src/app/features/recurring/recurring.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, signal, computed, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { form, FormField, required, min } from '@angular/forms/signals';
+import { form, FormField, required, min, validate } from '@angular/forms/signals';
 import { RecurringService, RecurringPayload } from '../../core/services/recurring.service';
 import { CategoryService } from '../../core/services/category.service';
 import { ToastService } from '../../shared/services/toast.service';
@@ -68,6 +68,7 @@ export class RecurringComponent implements OnInit {
     categoryId: '',
     type: 'DESPESA',
     defaultAmount: 0,
+    dueDay: null,
   });
 
   readonly recurringForm = form(this.model, (f) => {
@@ -75,13 +76,20 @@ export class RecurringComponent implements OnInit {
     required(f.categoryId, { message: 'Categoria obrigatória' });
     required(f.defaultAmount, { message: 'Valor obrigatório' });
     min(f.defaultAmount, 0.01, { message: 'Valor deve ser positivo' });
+    validate(f.dueDay, ({ value }) => {
+      const v = value();
+      return v != null && (v < 1 || v > 31)
+        ? { kind: 'range', message: 'Dia do vencimento deve ser entre 1 e 31' }
+        : undefined;
+    });
   });
 
   readonly formValid = computed(
     () =>
       this.recurringForm.description().valid() &&
       this.recurringForm.categoryId().valid() &&
-      this.recurringForm.defaultAmount().valid(),
+      this.recurringForm.defaultAmount().valid() &&
+      this.recurringForm.dueDay().valid(),
   );
 
   readonly filtered = computed(() => {
@@ -131,7 +139,7 @@ export class RecurringComponent implements OnInit {
 
   openCreate(): void {
     this.editingId.set(null);
-    this.model.set({ description: '', categoryId: '', type: 'DESPESA', defaultAmount: 0 });
+    this.model.set({ description: '', categoryId: '', type: 'DESPESA', defaultAmount: 0, dueDay: null });
     this.showForm.set(true);
   }
 
@@ -142,6 +150,7 @@ export class RecurringComponent implements OnInit {
       categoryId: r.category.id,
       type: r.type,
       defaultAmount: r.defaultAmount,
+      dueDay: r.dueDay ?? null,
     });
     this.showForm.set(true);
   }


### PR DESCRIPTION
## Contexto
aque-backend#19 (PR #28) adicionou o campo opcional `dueDay` (dia do vencimento, 1-31) em `RecurringTransaction`, usado pelo job de geração mensal pra calcular o `dueDate` das instâncias geradas — sem ele, continuam sem vencimento (mesmo comportamento de antes do campo existir). O formulário de recorrente ainda não expunha esse campo, então nenhum recorrente criado pela UI se beneficiava do indicador de "atrasados" do dashboard.

## Mudanças
- `RecurringTransaction`/`RecurringPayload` ganham `dueDay: number | null`
- Novo campo numérico opcional "Dia do vencimento" no form de Novo/Editar Recorrente
- Validação client-side (1-31) via `validate()` customizado, mesmo padrão já usado pro `amountPaid` negativo em `transaction-form.component.ts`
- `openCreate()`/`openEdit()` leem/escrevem o campo; `save()` já enviava o model inteiro, nada extra necessário ali

## Como testar
1. Criar um recorrente sem preencher "Dia do vencimento" → continua funcionando normal
2. Criar/editar um recorrente com "Dia do vencimento" preenchido (ex.: 5) → reabrir "Editar" confirma o valor salvo
3. Digitar um valor fora de 1-31 → bloqueado no client
4. Rodar "Gerar Recorrentes" pro mês → transação gerada tem `dueDate` preenchido

## Checklist
- [x] Testes adicionados (`recurring.service.spec.ts`, `recurring.component.spec.ts`)
- [x] Testes passando localmente (`npm test` — 140/140)
- [ ] Docs atualizadas — n/a
- [x] Breaking changes: não

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZUESsfDzwyhGpCoNUU8xA