### PR TITLE
feat(header): seletor de mês/ano e limpeza de toasts duplicados

### DIFF
--- a/docs/specs/35-month-year-picker-and-error-toast-cleanup.md
+++ b/docs/specs/35-month-year-picker-and-error-toast-cleanup.md
@@ -1,0 +1,75 @@
+# Seletor direto de mês/ano e limpeza de toasts de erro duplicados
+
+- **Issue:** #35 — https://github.com/BrininhoBru/aque-web/issues/35
+- **Status:** Draft
+- **Repo:** BrininhoBru/aque-web
+
+## Problema
+
+A navegação de mês/ano no header (`header.component.html:8-15`) só tem as setas `‹ mês ›` —
+voltar 8 meses exige 8 cliques. O `MonthYearService.setMonthYear(month, year)`
+(`core/services/month-year.service.ts`) já existe e faz exatamente isso, mas nenhuma UI o chama.
+
+Separadamente, `transaction-form.component.ts` e `dashboard.component.ts` disparam um
+`toast.error()` com mensagem fixa dentro dos callbacks `error:` de chamadas HTTP. Desde que
+`errorInterceptor` foi centralizado (commit `fbc4a5f`, 2026-08-06), ele já mostra um toast com a
+mensagem específica vinda do backend pra **todo** erro HTTP (exceto 401/403, tratados à parte).
+Esses componentes duplicam o aviso — o usuário vê dois toasts empilhados por um único erro.
+
+## Escopo
+
+**Dentro:**
+- Ao clicar no texto do mês/ano no header (`.header-month-display`), abrir um seletor (dropdown
+  de mês + input/stepper de ano, ou popover equivalente) que chama
+  `monthYear.setMonthYear(month, year)`
+- Botão/atalho "Hoje" que chama `setMonthYear` com o mês/ano corrente, visível quando o mês
+  selecionado é diferente do atual
+- Remover a chamada `this.toast.error('Erro ao carregar categorias.')` em
+  `transaction-form.component.ts:141` (callback `error:` do `categoryService.getAll()`)
+- Remover a chamada `this.toast.error('Erro ao carregar lançamento.')` em
+  `transaction-form.component.ts:175` (callback `error:` do `loadTransaction`) — mantém
+  `this.loading.set(false)` no mesmo callback
+- Remover a chamada `this.toast.error('Erro ao salvar lançamento.')` em
+  `transaction-form.component.ts:219` (callback `error:` do `save()`) — mantém
+  `this.saving.set(false)` no mesmo callback
+- Remover a chamada `this.toast.error('Erro ao carregar dados do dashboard.')` em
+  `dashboard.component.ts:286` — mantém `this.loading.set(false)` no mesmo callback
+
+**Fora:**
+- `transaction-form.component.ts:169` (`'Lançamento não encontrado.'`) **não** é removido — essa
+  chamada está no callback `next:` (a requisição teve sucesso, só não achou o id na lista), não é
+  um erro HTTP e não passa pelo `errorInterceptor`. Continua sendo o único feedback pra esse caso.
+- Nenhuma mudança em `error.interceptor.ts` — ele já está correto
+- Nenhuma mudança de layout/estilo do header além do necessário pro seletor
+- Nenhum toast novo em telas que hoje não têm
+
+## Abordagem
+
+O picker de mês/ano fica melhor como um pequeno componente/estado local dentro de
+`HeaderComponent` (signal de "aberto/fechado" + um `<select>` de mês e um input numérico de ano,
+ou 12 botões de mês — decisão de UI, não muda a API do `MonthYearService`). Fecha ao selecionar ou
+ao clicar fora.
+
+A remoção dos toasts duplicados é puramente subtrativa: apagar a linha `this.toast.error(...)` em
+cada um dos 4 pontos listados, mantendo o resto do callback intacto. Não precisa de teste novo —
+é remoção de um efeito colateral redundante, o comportamento coberto por teste (loading/saving
+sendo resetado) não muda.
+
+## Critério de aceite
+
+- [ ] Clicar no texto do mês/ano no header abre um seletor que permite escolher qualquer mês e
+      ano diretamente, sem precisar clicar em `‹`/`›` repetidamente
+- [ ] Selecionar um mês/ano no seletor atualiza `MonthYearService.selected()` e a tela recarrega
+      os dados desse mês (mesmo efeito de hoje ao usar as setas)
+- [ ] Existe uma forma de voltar ao mês/ano atual em um clique quando o selecionado for diferente
+- [ ] Um erro ao carregar categorias no formulário de lançamento mostra exatamente um toast (o do
+      `errorInterceptor`), não dois
+- [ ] Um erro ao carregar um lançamento existente (edição) mostra exatamente um toast
+- [ ] Um erro ao salvar (criar/editar) um lançamento mostra exatamente um toast
+- [ ] Um erro ao carregar dados do dashboard mostra exatamente um toast
+- [ ] Abrir o formulário de edição com um id de lançamento inexistente continua mostrando
+      "Lançamento não encontrado." e voltando pra tela anterior (comportamento preservado)
+
+## Questões em aberto
+
+Nenhuma.

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -4,6 +4,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideRouter } from '@angular/router';
 import { DashboardComponent } from './dashboard.component';
 import { DashboardSummary } from '../../core/models';
+import { ToastService } from '../../shared/services/toast.service';
 
 function summary(overrides: Partial<DashboardSummary>): DashboardSummary {
   return {
@@ -81,6 +82,29 @@ describe('DashboardComponent', () => {
       expect(component.summary()).not.toBeNull();
       expect(component.loading()).toBeFalse();
       httpMock.verify();
+    });
+  });
+
+  // aque-web#35: o componente disparava um toast.error() próprio em cima do que o
+  // errorInterceptor já mostra pra qualquer erro HTTP — usuário via 2 toasts por 1 erro só.
+  describe('load() — falha no forkJoin', () => {
+    it('não deve chamar toast.error localmente quando summary falha, e reseta loading (delegado ao errorInterceptor)', () => {
+      const { month, year } = component.monthYear.selected();
+      const base = '/api/dashboard';
+      const toast = TestBed.inject(ToastService);
+      spyOn(toast, 'error');
+
+      httpMock.expectOne(`${base}/by-category/${year}/${month}`).flush([]);
+      httpMock.expectOne(`${base}/evolution/${year}`).flush([]);
+      httpMock
+        .expectOne(`${base}/split/${year}/${month}`)
+        .flush({ message: 'not found' }, { status: 404, statusText: 'Not Found' });
+      httpMock
+        .expectOne(`${base}/summary/${year}/${month}`)
+        .flush('erro', { status: 500, statusText: 'Server Error' });
+
+      expect(component.loading()).toBeFalse();
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -20,7 +20,6 @@ import {
 } from 'ng-apexcharts';
 import { DashboardService } from '../../core/services/dashboard.service';
 import { MonthYearService } from '../../core/services/month-year.service';
-import { ToastService } from '../../shared/services/toast.service';
 import { BrlCurrencyPipe } from '../../shared/pipes/brl-currency.pipe';
 import { MonthYearPipe } from '../../shared/pipes/month-year.pipe';
 import { DashboardSummary, CategoryTotal, MonthEvolution, SplitResult } from '../../core/models';
@@ -76,7 +75,6 @@ const MONTH_LABELS = [
 })
 export class DashboardComponent {
   private readonly dashboardService = inject(DashboardService);
-  private readonly toast = inject(ToastService);
   readonly monthYear = inject(MonthYearService);
 
   readonly loading = signal(true);
@@ -283,7 +281,6 @@ export class DashboardComponent {
       },
       error: () => {
         if (requestId !== this.latestRequestId) return;
-        this.toast.error('Erro ao carregar dados do dashboard.');
         this.loading.set(false);
       },
     });

--- a/src/app/features/transactions/transaction-form/transaction-form.component.spec.ts
+++ b/src/app/features/transactions/transaction-form/transaction-form.component.spec.ts
@@ -4,6 +4,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
 import { TransactionFormComponent } from './transaction-form.component';
 import { MonthYearService } from '../../../core/services/month-year.service';
+import { ToastService } from '../../../shared/services/toast.service';
 
 describe('TransactionFormComponent', () => {
   let component: TransactionFormComponent;
@@ -132,6 +133,63 @@ describe('TransactionFormComponent', () => {
       component.setType('RECEITA');
       expect(component.transactionForm.type().value()).toBe('RECEITA');
       expect(component.transactionForm.categoryId().value()).toBe('');
+    });
+  });
+
+  // aque-web#35: o componente disparava um toast.error() próprio em cima do que o
+  // errorInterceptor já mostra pra qualquer erro HTTP — usuário via 2 toasts por 1 erro só.
+  describe('tratamento de erro HTTP (delegado ao errorInterceptor, não duplicado localmente)', () => {
+    let http: HttpTestingController;
+
+    beforeEach(() => {
+      http = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => http.verify());
+
+    it('não deve chamar toast.error localmente quando falha o carregamento de categorias', () => {
+      const toast = TestBed.inject(ToastService);
+      spyOn(toast, 'error');
+
+      http.expectOne((req) => req.url.includes('/api/categories')).flush('erro', { status: 500, statusText: 'Server Error' });
+
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it('não deve chamar toast.error localmente quando falha o carregamento do lançamento, e reseta loading', () => {
+      const toast = TestBed.inject(ToastService);
+      spyOn(toast, 'error');
+      http.expectOne((req) => req.url.includes('/api/categories')).flush([]);
+
+      component.loadTransaction('id-inexistente');
+      http.expectOne((req) => req.url.includes('/api/transactions')).flush('erro', { status: 500, statusText: 'Server Error' });
+
+      expect(component.loading()).toBeFalse();
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it('não deve chamar toast.error localmente quando falha o salvamento, e reseta saving', () => {
+      const toast = TestBed.inject(ToastService);
+      spyOn(toast, 'error');
+      http.expectOne((req) => req.url.includes('/api/categories')).flush([]);
+
+      component['model'].set({
+        description: 'Aluguel',
+        categoryId: 'cat-1',
+        type: 'DESPESA',
+        referenceMonth: '3',
+        referenceYear: 2026,
+        amountExpected: 1800,
+        amountPaid: null,
+        dueDate: null,
+      });
+      fixture.detectChanges();
+      component.save();
+
+      http.expectOne((req) => req.url.includes('/api/transactions')).flush('erro', { status: 500, statusText: 'Server Error' });
+
+      expect(component.saving()).toBeFalse();
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/features/transactions/transaction-form/transaction-form.component.ts
+++ b/src/app/features/transactions/transaction-form/transaction-form.component.ts
@@ -138,7 +138,9 @@ export class TransactionFormComponent implements OnInit {
   ngOnInit(): void {
     this.categoryService.getAll().subscribe({
       next: (data) => this.categories.set(data),
-      error: () => this.toast.error('Erro ao carregar categorias.'),
+      // errorInterceptor já loga/avisa o erro; precisa de um handler aqui só pra evitar
+      // que o RxJS relance a HttpErrorResponse por falta de observer de erro.
+      error: () => {},
     });
 
     const id = this.route.snapshot.paramMap.get('id');
@@ -172,7 +174,6 @@ export class TransactionFormComponent implements OnInit {
         this.loading.set(false);
       },
       error: () => {
-        this.toast.error('Erro ao carregar lançamento.');
         this.loading.set(false);
       },
     });
@@ -216,7 +217,6 @@ export class TransactionFormComponent implements OnInit {
         this.goBack();
       },
       error: () => {
-        this.toast.error('Erro ao salvar lançamento.');
         this.saving.set(false);
       },
     });

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -7,11 +7,19 @@
 <div class="header-month">
   <button class="btn-nav" (click)="monthYear.previousMonth()">‹</button>
 
-  <span class="header-month-display">
-    {{ monthYear.selected() | monthYear }}
-  </span>
+  <input
+    type="month"
+    class="header-month-display"
+    [value]="monthValue()"
+    (change)="onMonthChange($event)"
+    title="Escolher mês e ano"
+  />
 
   <button class="btn-nav" (click)="monthYear.nextMonth()">›</button>
+
+  @if (!isCurrentMonth()) {
+    <button class="btn-nav btn-today" (click)="goToToday()" title="Voltar pro mês atual">Hoje</button>
+  }
 </div>
 
 <button class="btn-nav" (click)="theme.toggle()" [title]="theme.dark() ? 'Modo claro' : 'Modo escuro'">

--- a/src/app/layout/header/header.component.spec.ts
+++ b/src/app/layout/header/header.component.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { HeaderComponent } from './header.component';
+import { MonthYearService } from '../../core/services/month-year.service';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+  let monthYear: MonthYearService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HeaderComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    monthYear = TestBed.inject(MonthYearService);
+    fixture.detectChanges();
+  });
+
+  it('deve criar o componente', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('deve exibir o mês/ano selecionado no input no formato YYYY-MM', () => {
+    monthYear.setMonthYear(3, 2026);
+    fixture.detectChanges();
+
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input[type="month"]');
+    expect(input.value).toBe('2026-03');
+  });
+
+  it('deve chamar setMonthYear com o mês e o ano corretos ao mudar o input', () => {
+    spyOn(monthYear, 'setMonthYear');
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input[type="month"]');
+
+    input.value = '2025-11';
+    input.dispatchEvent(new Event('change'));
+
+    expect(monthYear.setMonthYear).toHaveBeenCalledWith(11, 2025);
+  });
+
+  it('deve esconder o botão Hoje quando o mês selecionado é o mês atual', () => {
+    const now = new Date();
+    monthYear.setMonthYear(now.getMonth() + 1, now.getFullYear());
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.btn-today')).toBeNull();
+  });
+
+  it('deve mostrar o botão Hoje e voltar pro mês atual ao clicar quando o mês selecionado é diferente do atual', () => {
+    const now = new Date();
+    monthYear.setMonthYear(1, now.getFullYear() - 1);
+    fixture.detectChanges();
+
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('.btn-today');
+    expect(button).not.toBeNull();
+
+    button.click();
+    fixture.detectChanges();
+
+    expect(monthYear.month()).toBe(now.getMonth() + 1);
+    expect(monthYear.year()).toBe(now.getFullYear());
+  });
+});

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, computed } from '@angular/core';
 import { MonthYearService } from '../../core/services/month-year.service';
-import { MonthYearPipe } from '../../shared/pipes/month-year.pipe';
 import { AuthService } from '../../core/auth/auth.service';
 import { LayoutService } from '../layout.service';
 import { ThemeService } from '../../core/services/theme.service';
@@ -8,7 +7,7 @@ import { ThemeService } from '../../core/services/theme.service';
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [MonthYearPipe],
+  imports: [],
   templateUrl: './header.component.html',
   styles: [`
     :host {
@@ -24,12 +23,25 @@ import { ThemeService } from '../../core/services/theme.service';
     }
     .header-month-display {
       font-family: var(--font-serif);
-      font-size: 17px;
+      font-size: 15px;
       font-weight: 600;
       color: var(--color-ledger-ink);
       min-width: 140px;
       text-align: center;
       letter-spacing: -0.01em;
+      background: var(--color-ledger-card);
+      border: 1px solid var(--color-ledger-border-md);
+      border-radius: var(--radius-ledger-sm);
+      padding: 8px;
+      cursor: pointer;
+    }
+    .header-month-display:hover {
+      border-color: var(--color-ledger-border-st);
+    }
+    .btn-today {
+      width: auto;
+      padding: 0 10px;
+      font-size: 12px;
     }
     .btn-nav {
       display: flex;
@@ -80,4 +92,27 @@ export class HeaderComponent {
   readonly auth = inject(AuthService);
   readonly layout = inject(LayoutService);
   readonly theme = inject(ThemeService);
+
+  readonly monthValue = computed(() => {
+    const { month, year } = this.monthYear.selected();
+    return `${year}-${String(month).padStart(2, '0')}`;
+  });
+
+  readonly isCurrentMonth = computed(() => {
+    const now = new Date();
+    const { month, year } = this.monthYear.selected();
+    return month === now.getMonth() + 1 && year === now.getFullYear();
+  });
+
+  onMonthChange(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    if (!value) return;
+    const [year, month] = value.split('-').map(Number);
+    this.monthYear.setMonthYear(month, year);
+  }
+
+  goToToday(): void {
+    const now = new Date();
+    this.monthYear.setMonthYear(now.getMonth() + 1, now.getFullYear());
+  }
 }


### PR DESCRIPTION
## Resumo
Fase 1 do roadmap de UI/UX (issue #35): seletor direto de mês/ano no header e remoção de toasts de erro duplicados.

## Motivação
A navegação de mês/ano no header só tinha as setas `‹ ›` — voltar vários meses exigia vários cliques. Separadamente, `transaction-form.component.ts` e `dashboard.component.ts` disparavam um `toast.error()` próprio em cima do que o `errorInterceptor` já mostra pra todo erro HTTP desde que foi centralizado — o usuário via 2 avisos por 1 erro só.

## Mudanças
- `header.component.ts`/`.html`: troca o texto fixo por um `<input type="month">` nativo (sem overlay/popover customizado — nenhum padrão desse tipo existia no app) + botão "Hoje" quando o mês selecionado é diferente do atual
- Remove os 4 pontos de `toast.error()` duplicado em `transaction-form.component.ts` (categorias, carregar lançamento, salvar) e `dashboard.component.ts` (carregar dashboard)
- `dashboard.component.ts` perde a injeção de `ToastService`, que ficou sem uso
- 5 testes novos (`header.component.spec.ts`) + 4 testes de regressão (`transaction-form.component.spec.ts`, `dashboard.component.spec.ts`) garantindo que o componente não chama `toast.error` localmente nesses caminhos
- Spec da issue em `docs/specs/35-month-year-picker-and-error-toast-cleanup.md`

## Como testar
1. `npm start` (precisa do `aque-backend` rodando em `:8080`)
2. Clicar no mês/ano no header → abre o seletor nativo do navegador; trocar o valor atualiza a tela
3. Navegar pra outro mês → botão "Hoje" aparece; clicar volta pro mês atual e o botão some
4. Forçar um erro HTTP (ex.: derrubar o backend e tentar salvar um lançamento ou carregar o dashboard) → aparece só 1 toast, não 2

## Checklist
- [x] Testes adicionados (`npm test`: 155/155 passando)
- [x] Docs atualizadas (spec em `docs/specs/35-...md`)
- [ ] Breaking changes: não

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZUESsfDzwyhGpCoNUU8xA