### PR TITLE
chore(gerar-pr): alinha skill com padrões de mercado de descrição de PR

### DIFF
--- a/.claude/rules/standards.md
+++ b/.claude/rules/standards.md
@@ -84,9 +84,14 @@ builda e publica a imagem Docker no push pra `main` — não roda `npm test` nem
 
 ## Template de Pull Request
 Todo PR segue esta estrutura (a skill `/gerar-pr` já gera isso automaticamente):
-- **Contexto**: o que motivou a mudança
+- **Título**: Conventional Commits (`tipo(escopo): resumo`, `!` pra breaking change)
+- **Issue relacionada**: `Closes #N` / `Relates to #N`, quando houver
+- **Resumo**: o que foi feito, em 1-2 frases
+- **Motivação**: o que motivou a mudança
 - **Mudanças**: lista do que foi alterado
-- **Como testar**: passos para validar manualmente
+- **Como testar**: passos concretos e verificáveis (comando exato, não "teste a feature")
+- **Risco/Impacto**: muda contrato com o `aque-backend` ou adiciona variável de ambiente nova?
+- **Screenshot/GIF**: obrigatório quando o diff toca UI (`.html`/`.component.ts`)
 - **Checklist**: testes adicionados, docs atualizadas, breaking changes (sim/não)
 
 **Gap conhecido no aque-web**: não existe `.github/PULL_REQUEST_TEMPLATE.md` —

--- a/.claude/skills/gerar-pr/SKILL.md
+++ b/.claude/skills/gerar-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Gera uma descrição de Pull Request em português a partir das mudanças da branch atual
+description: Gera título (Conventional Commits) e descrição de Pull Request em português a partir das mudanças da branch atual, com link de issue, checklist de risco e lembrete de screenshot pra mudança de UI
 argument-hint: [branch-base]
 ---
 
@@ -7,11 +7,39 @@ argument-hint: [branch-base]
 
 !`git diff $ARGUMENTS...HEAD --stat`
 !`git log $ARGUMENTS...HEAD --oneline`
+!`git branch --show-current`
 
-Com base nas mudanças acima, gere uma descrição de PR em português com:
+## Issue relacionada
+
+Procure o número da issue, nesta ordem: (1) no nome da branch, se seguir um padrão com número;
+(2) em `docs/specs/<N>-*.md` cujo slug bata com o tema da branch/commits; (3) nos commits acima,
+se algum citar `#N`. Se achar, adicione `Closes #N` na descrição (ou `Relates to #N` se a PR não
+fecha a issue sozinha — ex.: várias PRs pra uma mesma issue grande). Se não achar nenhuma
+referência clara, não invente número — pergunte ao usuário ou omita a linha.
+
+Com base nas mudanças acima, gere:
+
+## Título do PR
+
+Formato Conventional Commits: `tipo(escopo): resumo imperativo`, mesmas regras de tipo/escopo da
+skill `commit-msg` deste repo. Use `!` depois do tipo pra breaking change (ex.: `feat(auth)!:
+...`). Isso importa porque, em squash-merge, o título do PR vira a mensagem do commit final em
+`dev`/`main` — sem o formato certo, quebra o Conventional Commits ali.
+
+## Descrição
 
 1. **Resumo** — o que foi feito, em 1-2 frases
 2. **Motivação** — por que essa mudança foi necessária
 3. **Mudanças** — lista dos principais pontos alterados
-4. **Como testar** — passos para validar manualmente
-5. **Checklist** — testes adicionados, docs atualizadas, breaking changes (sim/não)
+4. **Como testar** — passos concretos e verificáveis (ex.: comando exato a rodar, não "teste a
+   feature")
+5. **Risco/Impacto** — muda contrato com o `aque-backend` (rota, formato de payload, a convenção
+   401/403 documentada no `CLAUDE.md`)? Adiciona variável de ambiente nova? Se nenhum dos dois,
+   escreva "nenhum" explicitamente — não omita a seção
+6. **Screenshot/GIF** — se o diff toca `.html`/`.component.ts` de `features/` ou `layout/`, ou
+   qualquer outro arquivo visualmente relevante: inclua um lembrete explícito pra anexar
+   screenshot/GIF antes de abrir o PR. A skill não tira print sozinha — sinaliza a necessidade,
+   nunca inventa uma imagem nem inclui um placeholder
+7. **Checklist** — itens que dá pra confirmar em poucos segundos (ex.: "`npm test` passando
+   localmente", não "testado"), docs atualizadas (sim/não), breaking changes (sim/não), issue
+   linkada (sim/não/n-a)


### PR DESCRIPTION
## Resumo
Atualiza a skill `/gerar-pr` e a seção "Template de Pull Request" do `standards.md` pra incorporar práticas de mercado levantadas em pesquisa (título Conventional Commits, link de issue, checklist de risco, lembrete de screenshot).

## Motivação
A skill gerava só 5 seções fixas (Resumo/Motivação/Mudanças/Como testar/Checklist), sem título padronizado, sem link com a issue e sem nada de risco/impacto ou evidência visual pra mudança de UI — gaps comuns apontados em guias de PR de mercado.

## Mudanças
- `.claude/skills/gerar-pr/SKILL.md`: adiciona geração de título Conventional Commits (`!` pra breaking change), busca automática da issue relacionada (`Closes #N`/`Relates to #N`), seção de Risco/Impacto e lembrete de screenshot/GIF pra diff que toca UI
- `.claude/rules/standards.md`: atualiza a lista "Template de Pull Request" pra bater com o que a skill gera agora (também corrige um desalinhamento que já existia antes: o doc listava "Contexto" e a skill sempre gerou "Resumo" + "Motivação")

## Como testar
1. Rodar `/gerar-pr dev` numa branch com mudanças pendentes
2. Conferir que a descrição gerada inclui título sugerido, link de issue (quando aplicável), e as seções novas

## Risco/Impacto
Nenhum — mudança só em skill/doc, não afeta código de produção nem contrato de API.

## Checklist
- [x] Docs atualizadas (`standards.md`)
- [ ] Testes adicionados: n/a (skill, não código)
- [ ] Breaking changes: não

🤖 Generated with [Claude Code](https://claude.com/claude-code)