### PR TITLE
feat(transactions): search, column sorting and URL-persisted filters

### DIFF
--- a/docs/specs/36-transactions-table-search-sort-filter-persistence.md
+++ b/docs/specs/36-transactions-table-search-sort-filter-persistence.md
@@ -1,0 +1,80 @@
+# Busca, ordenação de colunas e persistência de filtros na tabela de lançamentos
+
+- **Issue:** #36 — https://github.com/BrininhoBru/aque-web/issues/36
+- **Status:** Draft
+- **Repo:** BrininhoBru/aque-web
+
+## Problema
+
+A tela de Lançamentos (`transactions.component.ts`/`.html`) filtra hoje só por categoria, tipo e
+status (`tx-filter-bar`, `transactions.component.html:24-74`), com os signals `filterCategoryId`,
+`filterType`, `filterStatus`. Não há busca por texto, as colunas da tabela (`ledger-table`,
+`transactions.component.html:101-113`) não são clicáveis pra ordenar, e trocar de rota (ou só
+recarregar) reseta todos os filtros pro estado inicial. Numa lista usada toda semana, isso custa
+cliques repetidos toda vez que o usuário procura algo específico.
+
+`TransactionService.getAll(filters)` só envia `month`/`year`/`categoryId`/`type`/`status` ao
+backend — o filtro combinado já acontece 100% client-side, no `computed()` `filtered()` sobre
+`transactions()` (dados do mês já carregados). Busca e ordenação por texto podem seguir o mesmo
+padrão, sem endpoint novo.
+
+## Escopo
+
+**Dentro:**
+- Input de busca por texto na `tx-filter-bar`, filtrando `filtered()` por
+  `description` (case-insensitive, substring)
+- Colunas ordenáveis por clique no `<th>`: Descrição, Categoria, Previsto, Pago, Vencimento —
+  alterna asc/desc, com indicador visual (seta) de qual coluna e direção está ativa
+- Persistência de `categoryId`/`type`/`status`/busca/coluna-de-ordenação/direção em query params
+  da rota (`?categoria=...&tipo=...&status=...&busca=...&sort=...&dir=...`), restaurados ao
+  entrar na tela
+- Chip de filtro rápido "Vencidos" / "Vencendo esta semana" na `tx-filter-bar`, calculado
+  client-side a partir de `dueDate` e `status` das transações já carregadas (mesmo critério que o
+  dashboard usa pra `totalOverdueCount`, mas sem chamar o endpoint do dashboard — os dados já
+  estão na tela)
+
+**Fora:**
+- Ordenação ou busca server-side — segue tudo client-side sobre os dados do mês selecionado
+- Paginação — fora de escopo aqui (nenhuma tela do app pagina hoje; volume mensal de lançamentos
+  é baixo o suficiente pra não justificar)
+- Mudança em `TransactionService`/`TransactionController` (backend) — nenhum parâmetro novo de
+  query
+- Aplicar o padrão de busca/sort em outras telas (Categorias, Pessoas, Recorrentes) — isso é a
+  Fase 3, issue #37, feita depois que este padrão estiver validado aqui
+
+## Abordagem
+
+Ordenação e busca entram como signals novos no `TransactionsComponent`
+(`sortColumn`, `sortDirection`, `searchText`), compostos no mesmo `computed()` que já produz
+`filtered()` — busca e sort aplicados depois dos filtros de categoria/tipo/status existentes, na
+mesma cadeia.
+
+Persistência usa `ActivatedRoute.queryParams` pra ler o estado inicial e `Router.navigate` (com
+`queryParamsHandling: 'merge'`) pra escrever a cada mudança — sem introduzir um serviço de estado
+novo, os signals continuam sendo a fonte de verdade local; a URL é só espelho pra sobreviver a
+navegação/reload.
+
+O chip de vencidos reaproveita a mesma lógica que aparece implícita no dashboard (`dueDate` no
+passado e `status === 'PENDENTE'`) — extrair como função local/pure, não chamar
+`DashboardService`.
+
+## Critério de aceite
+
+- [ ] Digitar no campo de busca filtra a tabela (desktop) e os cards (mobile) pela descrição,
+      case-insensitive, combinando com os filtros de categoria/tipo/status já ativos
+- [ ] Clicar no cabeçalho de uma coluna ordenável ordena a lista por ela; clicar de novo inverte
+      a direção; um indicador visual mostra coluna e direção ativas
+- [ ] Ordenação e busca respeitam os mesmos itens já filtrados por categoria/tipo/status (não
+      reordenam/buscam sobre a lista inteira do mês ignorando outros filtros)
+- [ ] Sair da tela de Lançamentos e voltar (ou dar F5) preserva categoria/tipo/status/busca/
+      ordenação selecionados anteriormente
+- [ ] Trocar de mês/ano (`MonthYearService`) mantém os filtros de categoria/tipo/status/busca/
+      ordenação ativos, recarregando só os dados
+- [ ] O chip "Vencidos" mostra somente lançamentos com `status = PENDENTE` e `dueDate` anterior à
+      data de hoje
+- [ ] "Limpar filtros" (botão já existente) também limpa busca, ordenação e o chip de vencidos, e
+      reflete isso na URL
+
+## Questões em aberto
+
+Nenhuma.

--- a/src/app/features/transactions/transactions.component.html
+++ b/src/app/features/transactions/transactions.component.html
@@ -23,6 +23,18 @@
 
   <!-- Filtros -->
   <div class="tx-filter-bar ledger-card">
+    <!-- Busca -->
+    <div class="tx-filter-category">
+      <label class="ledger-label">Busca</label>
+      <input
+        type="text"
+        class="ledger-input"
+        placeholder="Descrição..."
+        [value]="searchText()"
+        (input)="searchText.set($any($event.target).value)"
+      />
+    </div>
+
     <!-- Categoria -->
     <div class="tx-filter-category">
       <label class="ledger-label">Categoria</label>
@@ -68,6 +80,17 @@
       </div>
     </div>
 
+    <!-- Vencidos -->
+    <div style="display: flex; flex-direction: column;">
+      <label class="ledger-label">Vencimento</label>
+      <button
+        class="btn btn-sm"
+        [class.btn-primary]="filterOverdue()"
+        [class.btn-secondary]="!filterOverdue()"
+        (click)="toggleOverdue()"
+      >Vencidos</button>
+    </div>
+
     <button class="btn-ghost btn-sm" style="align-self: flex-end;" (click)="clearFilters()">
       Limpar filtros
     </button>
@@ -101,13 +124,23 @@
             <table class="ledger-table">
               <thead>
                 <tr>
-                  <th>Descrição</th>
-                  <th>Categoria</th>
+                  <th style="cursor: pointer;" (click)="setSort('description')">
+                    Descrição @if (sortColumn() === 'description') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
+                  </th>
+                  <th style="cursor: pointer;" (click)="setSort('category')">
+                    Categoria @if (sortColumn() === 'category') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
+                  </th>
                   <th>Tipo</th>
-                  <th class="col-num">Previsto</th>
-                  <th class="col-num">Pago</th>
+                  <th class="col-num" style="cursor: pointer;" (click)="setSort('amountExpected')">
+                    Previsto @if (sortColumn() === 'amountExpected') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
+                  </th>
+                  <th class="col-num" style="cursor: pointer;" (click)="setSort('amountPaid')">
+                    Pago @if (sortColumn() === 'amountPaid') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
+                  </th>
                   <th>Status</th>
-                  <th>Vencimento</th>
+                  <th style="cursor: pointer;" (click)="setSort('dueDate')">
+                    Vencimento @if (sortColumn() === 'dueDate') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
+                  </th>
                   <th></th>
                 </tr>
               </thead>

--- a/src/app/features/transactions/transactions.component.spec.ts
+++ b/src/app/features/transactions/transactions.component.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { provideRouter } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { TransactionsComponent } from './transactions.component';
 import { Transaction, Category } from '../../core/models';
 
@@ -111,6 +111,195 @@ describe('TransactionsComponent', () => {
       component.setFilterCategory('c2');
       component.clearFilters();
       expect(component.filtered().length).toBe(2);
+    });
+
+    it('clearFilters() também reseta busca, vencidos e ordenação', () => {
+      component.searchText.set('algo');
+      component.toggleOverdue();
+      component.setSort('description');
+      component.clearFilters();
+      expect(component.searchText()).toBe('');
+      expect(component.filterOverdue()).toBeFalse();
+      expect(component.sortColumn()).toBeNull();
+    });
+  });
+
+  describe('busca por texto (searchText)', () => {
+    beforeEach(() => {
+      component.transactions.set([
+        tx({ id: '1', description: 'Aluguel de março', type: 'DESPESA' }),
+        tx({ id: '2', description: 'Supermercado', type: 'DESPESA' }),
+      ]);
+    });
+
+    it('filtra por descrição, case-insensitive', () => {
+      component.searchText.set('aluguel');
+      expect(component.filtered().map((t) => t.id)).toEqual(['1']);
+    });
+
+    it('combina com outros filtros já ativos', () => {
+      component.setFilterType('RECEITA');
+      component.searchText.set('aluguel');
+      expect(component.filtered().length).toBe(0);
+    });
+  });
+
+  describe('ordenação de colunas (setSort)', () => {
+    it('ordena por descrição, ascendente', () => {
+      component.transactions.set([
+        tx({ id: '1', description: 'Banana' }),
+        tx({ id: '2', description: 'Abacaxi' }),
+      ]);
+      component.setSort('description');
+      expect(component.filtered().map((t) => t.id)).toEqual(['2', '1']);
+    });
+
+    it('clicar na mesma coluna de novo inverte a direção', () => {
+      component.transactions.set([
+        tx({ id: '1', description: 'Banana' }),
+        tx({ id: '2', description: 'Abacaxi' }),
+      ]);
+      component.setSort('description');
+      component.setSort('description');
+      expect(component.filtered().map((t) => t.id)).toEqual(['1', '2']);
+    });
+
+    it('trocar de coluna volta a ordenar ascendente', () => {
+      component.transactions.set([
+        tx({ id: '1', description: 'Banana', amountExpected: 100 }),
+        tx({ id: '2', description: 'Abacaxi', amountExpected: 300 }),
+      ]);
+      component.setSort('description');
+      component.setSort('description'); // desc: ['1', '2']
+      component.setSort('amountExpected'); // troca de coluna: volta pra asc
+      expect(component.filtered().map((t) => t.id)).toEqual(['1', '2']);
+    });
+
+    it('ordena por valor previsto numericamente', () => {
+      component.transactions.set([
+        tx({ id: '1', amountExpected: 300 }),
+        tx({ id: '2', amountExpected: 100 }),
+        tx({ id: '3', amountExpected: 200 }),
+      ]);
+      component.setSort('amountExpected');
+      expect(component.filtered().map((t) => t.id)).toEqual(['2', '3', '1']);
+    });
+
+    it('ordena por vencimento sem quebrar quando algum é null', () => {
+      component.transactions.set([
+        tx({ id: '1', dueDate: '2026-03-15' }),
+        tx({ id: '2', dueDate: null }),
+        tx({ id: '3', dueDate: '2026-01-01' }),
+      ]);
+      component.setSort('dueDate');
+      expect(component.filtered().map((t) => t.id)).toEqual(['2', '3', '1']);
+    });
+  });
+
+  describe('chip de vencidos (toggleOverdue)', () => {
+    it('mostra só lançamentos PENDENTE com vencimento no passado quando ativado', () => {
+      component.transactions.set([
+        tx({ id: '1', status: 'PENDENTE', dueDate: '2000-01-01' }),
+        tx({ id: '2', status: 'PENDENTE', dueDate: '2999-01-01' }),
+        tx({ id: '3', status: 'PAGO', dueDate: '2000-01-01' }),
+        tx({ id: '4', status: 'PENDENTE', dueDate: null }),
+      ]);
+      component.toggleOverdue();
+      expect(component.filtered().map((t) => t.id)).toEqual(['1']);
+    });
+
+    it('toggleOverdue() chamado de novo desativa o filtro', () => {
+      component.transactions.set([tx({ id: '1', status: 'PENDENTE', dueDate: '2000-01-01' })]);
+      component.toggleOverdue();
+      component.toggleOverdue();
+      expect(component.filtered().length).toBe(1);
+    });
+  });
+
+  describe('persistência de filtros na URL', () => {
+    describe('leitura inicial dos query params', () => {
+      function setupWithQueryParams(params: Record<string, string> = {}): void {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          imports: [TransactionsComponent],
+          providers: [
+            provideHttpClient(),
+            provideHttpClientTesting(),
+            provideRouter([]),
+            {
+              provide: ActivatedRoute,
+              useValue: { snapshot: { queryParamMap: convertToParamMap(params) } },
+            },
+          ],
+        });
+
+        fixture = TestBed.createComponent(TransactionsComponent);
+        component = fixture.componentInstance;
+        httpMock = TestBed.inject(HttpTestingController);
+      }
+
+      it('inicializa os filtros a partir dos query params da URL', () => {
+        setupWithQueryParams({
+          categoryId: 'c1',
+          type: 'DESPESA',
+          status: 'PENDENTE',
+          search: 'luz',
+          overdue: '1',
+          sortBy: 'description',
+          sortDir: 'desc',
+        });
+
+        expect(component.filterCategoryId()).toBe('c1');
+        expect(component.filterType()).toBe('DESPESA');
+        expect(component.filterStatus()).toBe('PENDENTE');
+        expect(component.searchText()).toBe('luz');
+        expect(component.filterOverdue()).toBeTrue();
+        expect(component.sortColumn()).toBe('description');
+        expect(component.sortDirection()).toBe('desc');
+      });
+
+      it('ignora valores inválidos na URL e usa os defaults', () => {
+        setupWithQueryParams({ type: 'LIXO', sortBy: 'campo-invalido', sortDir: 'lateral' });
+
+        expect(component.filterType()).toBe('TODOS');
+        expect(component.sortColumn()).toBeNull();
+        expect(component.sortDirection()).toBe('asc');
+      });
+    });
+
+    describe('escrita na URL', () => {
+      it('atualiza a URL quando um filtro muda', () => {
+        const router = TestBed.inject(Router);
+        spyOn(router, 'navigate');
+
+        component.setFilterType('RECEITA');
+        fixture.detectChanges();
+
+        expect(router.navigate).toHaveBeenCalledWith(
+          [],
+          jasmine.objectContaining({
+            queryParams: jasmine.objectContaining({ type: 'RECEITA' }),
+            queryParamsHandling: 'merge',
+          }),
+        );
+      });
+
+      it('remove o param da URL quando o filtro volta pro default', () => {
+        const router = TestBed.inject(Router);
+        component.setFilterType('RECEITA');
+        fixture.detectChanges();
+        spyOn(router, 'navigate');
+
+        component.setFilterType('TODOS');
+        fixture.detectChanges();
+
+        expect(router.navigate).toHaveBeenCalledWith(
+          [],
+          jasmine.objectContaining({
+            queryParams: jasmine.objectContaining({ type: null }),
+          }),
+        );
+      });
     });
   });
 

--- a/src/app/features/transactions/transactions.component.ts
+++ b/src/app/features/transactions/transactions.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, signal, computed, OnInit, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TransactionService, TransactionFilters } from '../../core/services/transaction.service';
 import { CategoryService } from '../../core/services/category.service';
 import { RecurringService } from '../../core/services/recurring.service';
@@ -11,6 +11,45 @@ import { BrlCurrencyPipe } from '../../shared/pipes/brl-currency.pipe';
 
 type FilterType = 'TODOS' | 'RECEITA' | 'DESPESA';
 type FilterStatus = 'TODOS' | 'PENDENTE' | 'PAGO';
+type SortColumn = 'description' | 'category' | 'amountExpected' | 'amountPaid' | 'dueDate';
+
+const SORT_COLUMNS: readonly SortColumn[] = [
+  'description',
+  'category',
+  'amountExpected',
+  'amountPaid',
+  'dueDate',
+];
+
+// fronteira de confiança: o valor vem da URL, o usuário pode editá-la à mão
+function pickValid<T extends string>(value: string | null, allowed: readonly T[], fallback: T): T;
+function pickValid<T extends string>(value: string | null, allowed: readonly T[], fallback: null): T | null;
+function pickValid<T extends string>(
+  value: string | null,
+  allowed: readonly T[],
+  fallback: T | null,
+): T | null {
+  return value !== null && (allowed as readonly string[]).includes(value) ? (value as T) : fallback;
+}
+
+function toIsoDate(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function compareByColumn(a: Transaction, b: Transaction, column: SortColumn): number {
+  switch (column) {
+    case 'description':
+      return a.description.localeCompare(b.description);
+    case 'category':
+      return a.category.name.localeCompare(b.category.name);
+    case 'amountExpected':
+      return a.amountExpected - b.amountExpected;
+    case 'amountPaid':
+      return (a.amountPaid ?? -1) - (b.amountPaid ?? -1);
+    case 'dueDate':
+      return (a.dueDate ?? '').localeCompare(b.dueDate ?? '');
+  }
+}
 
 @Component({
   selector: 'app-transactions',
@@ -94,6 +133,7 @@ export class TransactionsComponent implements OnInit {
   private readonly recurringService = inject(RecurringService);
   private readonly toast = inject(ToastService);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
   readonly monthYear = inject(MonthYearService);
 
   readonly transactions = signal<Transaction[]>([]);
@@ -104,18 +144,49 @@ export class TransactionsComponent implements OnInit {
   readonly generating = signal(false);
   readonly togglingId = signal<string | null>(null);
 
-  // Filtros
-  readonly filterCategoryId = signal<string>('');
-  readonly filterType = signal<FilterType>('TODOS');
-  readonly filterStatus = signal<FilterStatus>('TODOS');
+  // Filtros — inicializados a partir dos query params da URL, pra sobreviver a navegação/reload
+  readonly filterCategoryId = signal<string>(this.route.snapshot.queryParamMap.get('categoryId') ?? '');
+  readonly filterType = signal<FilterType>(
+    pickValid(this.route.snapshot.queryParamMap.get('type'), ['TODOS', 'RECEITA', 'DESPESA'], 'TODOS'),
+  );
+  readonly filterStatus = signal<FilterStatus>(
+    pickValid(this.route.snapshot.queryParamMap.get('status'), ['TODOS', 'PENDENTE', 'PAGO'], 'TODOS'),
+  );
+  readonly searchText = signal<string>(this.route.snapshot.queryParamMap.get('search') ?? '');
+  readonly filterOverdue = signal<boolean>(this.route.snapshot.queryParamMap.get('overdue') === '1');
+  readonly sortColumn = signal<SortColumn | null>(
+    pickValid(this.route.snapshot.queryParamMap.get('sortBy'), SORT_COLUMNS, null),
+  );
+  readonly sortDirection = signal<'asc' | 'desc'>(
+    pickValid(this.route.snapshot.queryParamMap.get('sortDir'), ['asc', 'desc'], 'asc'),
+  );
 
   private latestRequestId = 0;
 
-  // Recarrega ao mudar mês/ano global
   constructor() {
+    // Recarrega ao mudar mês/ano global
     effect(() => {
       const { month, year } = this.monthYear.selected();
       this.load(month, year);
+    });
+
+    // Espelha os filtros na URL — sem debounce: volume de teclas de um app pessoal
+    // não justifica a complexidade extra
+    effect(() => {
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: {
+          categoryId: this.filterCategoryId() || null,
+          type: this.filterType() === 'TODOS' ? null : this.filterType(),
+          status: this.filterStatus() === 'TODOS' ? null : this.filterStatus(),
+          search: this.searchText() || null,
+          overdue: this.filterOverdue() ? '1' : null,
+          sortBy: this.sortColumn(),
+          sortDir: this.sortColumn() ? this.sortDirection() : null,
+        },
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
     });
   }
 
@@ -147,14 +218,29 @@ export class TransactionsComponent implements OnInit {
     });
   }
 
-  // Filtros aplicados localmente (evita múltiplas requisições)
+  // Filtros, busca, chip de vencidos e ordenação aplicados localmente (evita múltiplas requisições)
   readonly filtered = computed(() => {
-    return this.transactions().filter((t) => {
+    const search = this.searchText().trim().toLowerCase();
+    const overdueOnly = this.filterOverdue();
+    const todayIso = toIsoDate(new Date());
+
+    let list = this.transactions().filter((t) => {
       const catOk = !this.filterCategoryId() || t.category.id === this.filterCategoryId();
       const typeOk = this.filterType() === 'TODOS' || t.type === this.filterType();
       const statusOk = this.filterStatus() === 'TODOS' || t.status === this.filterStatus();
-      return catOk && typeOk && statusOk;
+      const searchOk = !search || t.description.toLowerCase().includes(search);
+      const overdueOk =
+        !overdueOnly || (t.status === 'PENDENTE' && !!t.dueDate && t.dueDate < todayIso);
+      return catOk && typeOk && statusOk && searchOk && overdueOk;
     });
+
+    const column = this.sortColumn();
+    if (column) {
+      const dir = this.sortDirection() === 'asc' ? 1 : -1;
+      list = [...list].sort((a, b) => dir * compareByColumn(a, b, column));
+    }
+
+    return list;
   });
 
   readonly totalExpected = computed(() =>
@@ -193,10 +279,27 @@ export class TransactionsComponent implements OnInit {
     this.filterCategoryId.set(id);
   }
 
+  setSort(column: SortColumn): void {
+    if (this.sortColumn() === column) {
+      this.sortDirection.update((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      this.sortColumn.set(column);
+      this.sortDirection.set('asc');
+    }
+  }
+
+  toggleOverdue(): void {
+    this.filterOverdue.update((v) => !v);
+  }
+
   clearFilters(): void {
     this.filterType.set('TODOS');
     this.filterStatus.set('TODOS');
     this.filterCategoryId.set('');
+    this.searchText.set('');
+    this.filterOverdue.set(false);
+    this.sortColumn.set(null);
+    this.sortDirection.set('asc');
   }
 
   generateRecurring(): void {


### PR DESCRIPTION
Closes #36

## Resumo
Adiciona busca por texto, ordenação clicável nas colunas e persistência de filtros na URL na tela de Lançamentos.

## Motivação
A tabela só filtrava por categoria/tipo/status, sem busca, sem ordenação de coluna, e perdia todo filtro ao sair da tela e voltar — atrito real numa lista usada toda semana.

## Mudanças
- Busca por texto na descrição, chip "Vencidos" e ordenação clicável nas colunas (Descrição, Categoria, Previsto, Pago, Vencimento) — tudo client-side sobre os dados do mês já carregados, sem endpoint novo
- Filtros de categoria/tipo/status/busca/ordenação/vencidos passam a espelhar nos query params da URL (`categoryId`, `type`, `status`, `search`, `overdue`, `sortBy`, `sortDir`) — primeiro uso de `ActivatedRoute`/`Router` com query params no app, não havia padrão prévio a seguir
- Valores de query param são validados contra uma lista de permitidos antes de virar estado (usuário pode editar a URL à mão)
- `clearFilters()` passa a zerar também busca/vencidos/ordenação

## Como testar
1. `npm start` (precisa do `aque-backend` rodando em `:8080`)
2. Na tela de Lançamentos: digitar na busca, clicar nas colunas (confirma alternância asc/desc e troca de coluna volta pra asc), ativar "Vencidos"
3. Sair da tela e voltar (e dar F5) — confirma que tudo persiste via URL
4. Trocar de mês/ano — confirma que os filtros continuam ativos

## Risco/Impacto
Nenhum — mudança só client-side, sem tocar `aque-backend` nem variável de ambiente nova.

## Screenshot/GIF
Diff toca UI (`transactions.component.html`) — recomendo anexar um screenshot/GIF da busca+ordenação antes do merge; não gerei um por não ter testado num navegador real nesta sessão.

## Checklist
- [x] Testes adicionados (`npm test`: 169/169 passando)
- [x] Docs atualizadas (spec em `docs/specs/36-...md`)
- [ ] Breaking changes: não
- [ ] Screenshot/GIF: pendente (ver acima)

🤖 Generated with [Claude Code](https://claude.com/claude-code)