### PR TITLE
feat(transactions,recurring): bulk payment actions, undo-delete, recurring search/sort

### DIFF
--- a/docs/specs/37-bulk-payment-undo-delete-reuse-table-pattern.md
+++ b/docs/specs/37-bulk-payment-undo-delete-reuse-table-pattern.md
@@ -1,0 +1,87 @@
+# Ações em lote, exclusão com desfazer e reuso do padrão de tabela em Recorrentes
+
+- **Issue:** #37 — https://github.com/BrininhoBru/aque-web/issues/37
+- **Status:** Draft
+- **Repo:** BrininhoBru/aque-web
+
+## Problema
+
+Na tabela de Lançamentos, marcar vários itens como pago exige um clique por linha
+(`togglePayment(t)`, `transactions.component.html:148-155`) — comum no início do mês, quando
+várias contas chegam de uma vez. Excluir um lançamento usa um modal bloqueante
+(`confirmDeleteId`, `transactions.component.html:304-324`) que interrompe o fluxo pra uma ação
+that dá pra desfazer.
+
+Separadamente, a Fase 2 (#36) valida um padrão de busca+ordenação client-side na tabela de
+Lançamentos. A tela de Recorrentes (`recurring.component.ts`/`.html`) usa uma tabela real do
+mesmo formato (`<th>Descrição</th><th>Categoria</th><th>Tipo</th>`,
+`recurring.component.html:53-57`) e hoje não tem nenhum dos dois.
+
+Categorias e Pessoas foram avaliadas e **não entram** neste reuso: nenhuma das duas usa
+`<table>` (`categories.component.html`/`persons.component.html` são listas/cards), e o volume é
+pequeno por natureza — 13 categorias predefinidas + custom, e uma lista de pessoas de uma casa
+(tipicamente 2-5). Busca/ordenação nessas telas não se paga no tamanho de dado que elas têm.
+
+## Escopo
+
+**Dentro:**
+- Checkbox de seleção por linha na tabela de Lançamentos (desktop) + checkbox "selecionar todos
+  os visíveis" no cabeçalho
+- Ação em lote "Marcar como pago" / "Marcar como pendente" pras linhas selecionadas, disparando
+  `TransactionService.updatePayment` em paralelo (`forkJoin` ou equivalente) para os ids
+  selecionados
+- Excluir lançamento (desktop e mobile) passa a chamar `toast` com ação "Desfazer": a exclusão
+  real (`TransactionService.delete`) só dispara depois de uma janela sem desfazer (ex.: os
+  mesmos ~4s do auto-dismiss do toast); clicar "Desfazer" cancela a exclusão
+- Aplicar o mesmo padrão de busca-por-texto + ordenação de coluna da issue #36 na tabela de
+  Recorrentes (colunas Descrição, Categoria, Tipo, Valor padrão)
+
+**Fora:**
+- Endpoint de bulk update no backend — reaproveita `updatePayment` existente por id
+- Seleção múltipla ou exclusão com desfazer na view mobile (cards) — fica só na tabela desktop
+  nesta fase; a FAB e os botões de card mobile continuam como estão
+- Busca/ordenação em Categorias ou Pessoas (ver justificativa em Problema)
+- Modal de confirmação de exclusão continua existindo pra outras entidades (Categorias, Pessoas,
+  Recorrentes) — só Lançamentos migra pro padrão de toast com desfazer nesta fase
+
+## Abordagem
+
+Seleção múltipla entra como um `signal<Set<string>>` de ids selecionados no
+`TransactionsComponent`, populado/limpo pelos checkboxes; a barra de ação em lote só aparece
+quando o set não está vazio. O bulk usa `forkJoin` sobre um array de `updatePayment$` — volume
+mensal de lançamentos é baixo o bastante pra isso ser aceitável sem paginação/streaming.
+
+O undo-delete substitui a chamada imediata de `TransactionService.delete` por um
+`setTimeout`/temporizador guardado num signal; "Desfazer" cancela o timer antes dele disparar. O
+`ToastService` (`shared/services/toast.service.ts`) precisa de uma variante que aceite uma ação
+(hoje só tem `message`/`type`) — estender a interface `Toast` com um campo opcional
+`action?: { label: string; onClick: () => void }`, sem quebrar os usos existentes que não passam
+ação.
+
+Recorrentes reaproveita a mesma lógica de sort/busca implementada na issue #36 — extrair como
+composição de signals seguindo o mesmo padrão, não como serviço/diretiva compartilhada nova
+(dois usos não justificam abstração ainda; reavaliar se um terceiro aparecer).
+
+## Critério de aceite
+
+- [ ] Selecionar uma ou mais linhas na tabela de Lançamentos (desktop) habilita uma ação em lote
+      visível de marcar como pago
+- [ ] Confirmar a ação em lote atualiza o status de todas as linhas selecionadas e limpa a
+      seleção
+- [ ] Uma falha ao atualizar uma das linhas do lote não impede as demais de serem atualizadas, e
+      informa quais falharam
+- [ ] Excluir um lançamento mostra um toast com opção "Desfazer" em vez de remover a linha
+      imediatamente
+- [ ] Clicar "Desfazer" dentro da janela de tempo mantém o lançamento intacto (nenhuma chamada
+      DELETE é feita)
+- [ ] Deixar o toast expirar sem desfazer efetivamente exclui o lançamento
+- [ ] A tabela de Recorrentes ganha busca por descrição e ordenação clicável nas colunas
+      Descrição/Categoria/Tipo/Valor padrão, com o mesmo comportamento (client-side, sem chamada
+      nova ao backend) validado na issue #36
+- [ ] Categorias e Pessoas continuam sem busca/ordenação — nenhuma mudança nessas duas telas
+
+## Questões em aberto
+
+- Duração exata da janela de desfazer (usar os ~4s do auto-dismiss atual do `ToastService`, ou um
+  valor maior específico pra ações destrutivas?) — decidir na implementação, não bloqueia o
+  design geral.

--- a/src/app/features/recurring/recurring.component.html
+++ b/src/app/features/recurring/recurring.component.html
@@ -14,15 +14,28 @@
   </div>
 
   <!-- Filtros -->
-  <div class="btn-row">
-    @for (opt of [['ATIVOS', 'Ativos'], ['INATIVOS', 'Inativos'], ['TODOS', 'Todos']]; track opt[0]) {
-      <button
-        class="btn btn-sm"
-        [class.btn-primary]="filterActive() === opt[0]"
-        [class.btn-secondary]="filterActive() !== opt[0]"
-        (click)="setFilter(opt[0])"
-      >{{ opt[1] }}</button>
-    }
+  <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: flex-end;">
+    <div style="display: flex; flex-direction: column; min-width: 10rem; max-width: 16rem;">
+      <label class="ledger-label">Busca</label>
+      <input
+        type="text"
+        class="ledger-input"
+        placeholder="Descrição..."
+        [value]="searchText()"
+        (input)="searchText.set($any($event.target).value)"
+      />
+    </div>
+
+    <div class="btn-row">
+      @for (opt of [['ATIVOS', 'Ativos'], ['INATIVOS', 'Inativos'], ['TODOS', 'Todos']]; track opt[0]) {
+        <button
+          class="btn btn-sm"
+          [class.btn-primary]="filterActive() === opt[0]"
+          [class.btn-secondary]="filterActive() !== opt[0]"
+          (click)="setFilter(opt[0])"
+        >{{ opt[1] }}</button>
+      }
+    </div>
   </div>
 
   <!-- Loading -->
@@ -50,10 +63,18 @@
             <table class="ledger-table">
               <thead>
                 <tr>
-                  <th>Descrição</th>
-                  <th>Categoria</th>
-                  <th>Tipo</th>
-                  <th class="col-num">Valor padrão</th>
+                  <th style="cursor: pointer;" (click)="setSort('description')">
+                    Descrição @if (sortColumn() === 'description') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
+                  </th>
+                  <th style="cursor: pointer;" (click)="setSort('category')">
+                    Categoria @if (sortColumn() === 'category') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
+                  </th>
+                  <th style="cursor: pointer;" (click)="setSort('type')">
+                    Tipo @if (sortColumn() === 'type') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
+                  </th>
+                  <th class="col-num" style="cursor: pointer;" (click)="setSort('defaultAmount')">
+                    Valor padrão @if (sortColumn() === 'defaultAmount') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
+                  </th>
                   <th></th>
                 </tr>
               </thead>

--- a/src/app/features/recurring/recurring.component.spec.ts
+++ b/src/app/features/recurring/recurring.component.spec.ts
@@ -64,6 +64,89 @@ describe('RecurringComponent', () => {
     });
   });
 
+  describe('busca por texto (searchText)', () => {
+    beforeEach(() => {
+      component.recurrings.set([
+        recurring({ id: '1', description: 'Aluguel', active: true }),
+        recurring({ id: '2', description: 'Internet', active: true }),
+      ]);
+    });
+
+    it('filtra por descrição, case-insensitive', () => {
+      component.searchText.set('aluguel');
+      expect(component.filtered().map((r) => r.id)).toEqual(['1']);
+    });
+
+    it('combina com o filtro de ativo/inativo já existente', () => {
+      component.recurrings.set([
+        recurring({ id: '1', description: 'Aluguel', active: false }),
+        recurring({ id: '2', description: 'Aluguel', active: true }),
+      ]);
+      component.searchText.set('aluguel');
+      expect(component.filtered().map((r) => r.id)).toEqual(['2']);
+    });
+  });
+
+  describe('ordenação de colunas (setSort)', () => {
+    it('ordena por descrição, ascendente', () => {
+      component.recurrings.set([
+        recurring({ id: '1', description: 'Internet' }),
+        recurring({ id: '2', description: 'Aluguel' }),
+      ]);
+      component.setSort('description');
+      expect(component.filtered().map((r) => r.id)).toEqual(['2', '1']);
+    });
+
+    it('clicar na mesma coluna de novo inverte a direção', () => {
+      component.recurrings.set([
+        recurring({ id: '1', description: 'Internet' }),
+        recurring({ id: '2', description: 'Aluguel' }),
+      ]);
+      component.setSort('description');
+      component.setSort('description');
+      expect(component.filtered().map((r) => r.id)).toEqual(['1', '2']);
+    });
+
+    it('trocar de coluna volta a ordenar ascendente', () => {
+      component.recurrings.set([
+        recurring({ id: '1', description: 'Internet', defaultAmount: 100 }),
+        recurring({ id: '2', description: 'Aluguel', defaultAmount: 300 }),
+      ]);
+      component.setSort('description');
+      component.setSort('description'); // desc: ['1', '2']
+      component.setSort('defaultAmount'); // troca de coluna: volta pra asc
+      expect(component.filtered().map((r) => r.id)).toEqual(['1', '2']);
+    });
+
+    it('ordena por categoria (nome)', () => {
+      component.recurrings.set([
+        recurring({ id: '1', category: receitaCategory }), // Salário
+        recurring({ id: '2', category: despesaCategory }), // Aluguel
+      ]);
+      component.setSort('category');
+      expect(component.filtered().map((r) => r.id)).toEqual(['2', '1']);
+    });
+
+    it('ordena por tipo', () => {
+      component.recurrings.set([
+        recurring({ id: '1', type: 'RECEITA' }),
+        recurring({ id: '2', type: 'DESPESA' }),
+      ]);
+      component.setSort('type');
+      expect(component.filtered().map((r) => r.id)).toEqual(['2', '1']);
+    });
+
+    it('ordena por valor padrão numericamente', () => {
+      component.recurrings.set([
+        recurring({ id: '1', defaultAmount: 300 }),
+        recurring({ id: '2', defaultAmount: 100 }),
+        recurring({ id: '3', defaultAmount: 200 }),
+      ]);
+      component.setSort('defaultAmount');
+      expect(component.filtered().map((r) => r.id)).toEqual(['2', '3', '1']);
+    });
+  });
+
   describe('categoriesByType()', () => {
     beforeEach(() => {
       component.categories.set([despesaCategory, receitaCategory]);

--- a/src/app/features/recurring/recurring.component.ts
+++ b/src/app/features/recurring/recurring.component.ts
@@ -7,6 +7,20 @@ import { ToastService } from '../../shared/services/toast.service';
 import { RecurringTransaction, Category } from '../../core/models';
 
 type FilterActive = 'TODOS' | 'ATIVOS' | 'INATIVOS';
+type SortColumn = 'description' | 'category' | 'type' | 'defaultAmount';
+
+function compareByColumn(a: RecurringTransaction, b: RecurringTransaction, column: SortColumn): number {
+  switch (column) {
+    case 'description':
+      return a.description.localeCompare(b.description);
+    case 'category':
+      return a.category.name.localeCompare(b.category.name);
+    case 'type':
+      return a.type.localeCompare(b.type);
+    case 'defaultAmount':
+      return a.defaultAmount - b.defaultAmount;
+  }
+}
 
 @Component({
   selector: 'app-recurring',
@@ -62,6 +76,9 @@ export class RecurringComponent implements OnInit {
   readonly editingId = signal<string | null>(null);
   readonly confirmDeactivateId = signal<string | null>(null);
   readonly filterActive = signal<FilterActive>('ATIVOS');
+  readonly searchText = signal<string>('');
+  readonly sortColumn = signal<SortColumn | null>(null);
+  readonly sortDirection = signal<'asc' | 'desc'>('asc');
 
   private readonly model = signal<RecurringPayload>({
     description: '',
@@ -94,11 +111,21 @@ export class RecurringComponent implements OnInit {
 
   readonly filtered = computed(() => {
     const f = this.filterActive();
-    return this.recurrings().filter((r) => {
-      if (f === 'ATIVOS') return r.active;
-      if (f === 'INATIVOS') return !r.active;
-      return true;
+    const search = this.searchText().trim().toLowerCase();
+
+    let list = this.recurrings().filter((r) => {
+      const activeOk = f === 'TODOS' || (f === 'ATIVOS' ? r.active : !r.active);
+      const searchOk = !search || r.description.toLowerCase().includes(search);
+      return activeOk && searchOk;
     });
+
+    const column = this.sortColumn();
+    if (column) {
+      const dir = this.sortDirection() === 'asc' ? 1 : -1;
+      list = [...list].sort((a, b) => dir * compareByColumn(a, b, column));
+    }
+
+    return list;
   });
 
   readonly categoriesByType = computed(() => {
@@ -130,6 +157,15 @@ export class RecurringComponent implements OnInit {
 
   setFilter(f: string): void {
     this.filterActive.set(f as FilterActive);
+  }
+
+  setSort(column: SortColumn): void {
+    if (this.sortColumn() === column) {
+      this.sortDirection.update((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      this.sortColumn.set(column);
+      this.sortDirection.set('asc');
+    }
   }
 
   setType(type: string): void {

--- a/src/app/features/transactions/transactions.component.html
+++ b/src/app/features/transactions/transactions.component.html
@@ -96,6 +96,24 @@
     </button>
   </div>
 
+  <!-- Ação em lote (só desktop) -->
+  @if (selectedIds().size > 0) {
+    <div class="ledger-card hidden md:flex" style="padding: 0.75rem 1.25rem; align-items: center; gap: 0.75rem;">
+      <span class="text-body-sm" style="color: var(--color-ledger-ink-md)">
+        {{ selectedIds().size }} selecionado(s)
+      </span>
+      <button class="btn-secondary btn-sm" [disabled]="bulkUpdating()" (click)="bulkUpdatePayment(true)">
+        Marcar como pago
+      </button>
+      <button class="btn-secondary btn-sm" [disabled]="bulkUpdating()" (click)="bulkUpdatePayment(false)">
+        Marcar como pendente
+      </button>
+      <button class="btn-ghost btn-sm" style="margin-left: auto;" (click)="clearSelection()">
+        Cancelar seleção
+      </button>
+    </div>
+  }
+
   <!-- Loading -->
   @if (loading()) {
     <div style="display: flex; align-items: center; justify-content: center; padding: 4rem 0;">
@@ -124,6 +142,13 @@
             <table class="ledger-table">
               <thead>
                 <tr>
+                  <th style="width: 2rem;">
+                    <input
+                      type="checkbox"
+                      [checked]="selectedIds().size > 0 && filtered().every((t) => isSelected(t.id))"
+                      (change)="toggleSelectAll()"
+                    />
+                  </th>
                   <th style="cursor: pointer;" (click)="setSort('description')">
                     Descrição @if (sortColumn() === 'description') { {{ sortDirection() === 'asc' ? '▲' : '▼' }} }
                   </th>
@@ -146,7 +171,10 @@
               </thead>
               <tbody>
                 @for (t of filtered(); track t.id) {
-                  <tr>
+                  <tr [style.opacity]="pendingDeleteId() === t.id ? 0.4 : 1">
+                    <td>
+                      <input type="checkbox" [checked]="isSelected(t.id)" (change)="toggleSelect(t.id)" />
+                    </td>
                     <td>
                       <div style="display: flex; align-items: center; gap: 0.5rem; min-width: 0;">
                         @if (t.recurringId) {
@@ -182,7 +210,7 @@
                         type="button"
                         [class]="t.status === 'PAGO' ? 'badge-paid' : 'badge-pending'"
                         style="cursor: pointer;"
-                        [disabled]="togglingId() === t.id"
+                        [disabled]="togglingId() === t.id || pendingDeleteId() === t.id"
                         [title]="t.status === 'PAGO' ? 'Marcar como pendente' : 'Marcar como pago'"
                         (click)="togglePayment(t)"
                       >{{ t.status }}</button>
@@ -192,12 +220,12 @@
                     </td>
                     <td>
                       <div style="display: flex; align-items: center; gap: 2px;">
-                        <button class="btn-ghost btn-icon" (click)="goToEdit(t.id)" title="Editar">
+                        <button class="btn-ghost btn-icon" [disabled]="pendingDeleteId() === t.id" (click)="goToEdit(t.id)" title="Editar">
                           <svg width="13" height="13" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 000-1.41l-2.34-2.34a1 1 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
                           </svg>
                         </button>
-                        <button class="btn-danger btn-icon" (click)="askDelete(t.id)" title="Excluir">
+                        <button class="btn-danger btn-icon" [disabled]="pendingDeleteId() === t.id" (click)="askDelete(t.id)" title="Excluir">
                           <svg width="13" height="13" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M6 19c0 1.1.9 2 2 2h8a2 2 0 002-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
                           </svg>
@@ -209,7 +237,7 @@
               </tbody>
               <tfoot>
                 <tr>
-                  <td colspan="3" style="color: var(--color-ledger-ink-md);">Totais do mês</td>
+                  <td colspan="4" style="color: var(--color-ledger-ink-md);">Totais do mês</td>
                   <td class="col-num" style="color: var(--color-ledger-negative);">{{ totalExpected() | brlCurrency }}</td>
                   <td class="col-num" style="color: var(--color-ledger-positive);">{{ totalPaid() | brlCurrency }}</td>
                   <td colspan="3">
@@ -238,7 +266,7 @@
         </div>
       } @else {
         @for (t of filtered(); track t.id) {
-          <div class="tx-card ledger-card">
+          <div class="tx-card ledger-card" [style.opacity]="pendingDeleteId() === t.id ? 0.4 : 1">
             <div class="tx-card-top">
               <div class="tx-card-desc">
                 @if (t.recurringId) {
@@ -268,7 +296,7 @@
                   type="button"
                   [class]="t.status === 'PAGO' ? 'badge-paid' : 'badge-pending'"
                   style="cursor: pointer;"
-                  [disabled]="togglingId() === t.id"
+                  [disabled]="togglingId() === t.id || pendingDeleteId() === t.id"
                   [title]="t.status === 'PAGO' ? 'Marcar como pendente' : 'Marcar como pago'"
                   (click)="togglePayment(t)"
                 >{{ t.status }}</button>
@@ -289,12 +317,12 @@
                 </div>
               </div>
               <div class="tx-card-actions">
-                <button class="btn-ghost btn-icon" (click)="goToEdit(t.id)" title="Editar">
+                <button class="btn-ghost btn-icon" [disabled]="pendingDeleteId() === t.id" (click)="goToEdit(t.id)" title="Editar">
                   <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 000-1.41l-2.34-2.34a1 1 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
                   </svg>
                 </button>
-                <button class="btn-danger btn-icon" (click)="askDelete(t.id)" title="Excluir">
+                <button class="btn-danger btn-icon" [disabled]="pendingDeleteId() === t.id" (click)="askDelete(t.id)" title="Excluir">
                   <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M6 19c0 1.1.9 2 2 2h8a2 2 0 002-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
                   </svg>
@@ -333,25 +361,3 @@
   </svg>
 </button>
 
-<!-- Modal: Confirmação de exclusão -->
-@if (confirmDeleteId()) {
-  <div class="fixed inset-0 z-40 flex items-center justify-center p-4" style="background: rgba(44, 36, 22, 0.5); backdrop-filter: blur(4px)">
-    <div class="ledger-card w-full max-w-xs" style="display: flex; flex-direction: column; gap: 1.25rem; padding: 1.5rem;">
-      <div style="display: flex; flex-direction: column; align-items: center; gap: 0.75rem; text-align: center;">
-        <div style="width: 48px; height: 48px; border-radius: 50%; background: var(--color-ledger-negative-bg); border: 1px solid var(--color-ledger-negative-bd); display: flex; align-items: center; justify-content: center;">
-          <svg width="22" height="22" fill="currentColor" viewBox="0 0 24 24" style="color: var(--color-ledger-negative)">
-            <path d="M6 19c0 1.1.9 2 2 2h8a2 2 0 002-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
-          </svg>
-        </div>
-        <div>
-          <p class="ledger-h3">Excluir lançamento?</p>
-          <p class="text-body-sm mt-1" style="color: var(--color-ledger-ink-lt)">Esta ação não pode ser desfeita.</p>
-        </div>
-      </div>
-      <div style="display: flex; gap: 0.5rem;">
-        <button class="btn-secondary" style="flex: 1;" (click)="cancelDelete()">Cancelar</button>
-        <button class="btn-danger" style="flex: 1;" (click)="confirmDelete()">Excluir</button>
-      </div>
-    </div>
-  </div>
-}

--- a/src/app/features/transactions/transactions.component.spec.ts
+++ b/src/app/features/transactions/transactions.component.spec.ts
@@ -4,6 +4,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { TransactionsComponent } from './transactions.component';
 import { Transaction, Category } from '../../core/models';
+import { ToastService } from '../../shared/services/toast.service';
 
 const despesaCategory: Category = { id: 'c1', name: 'Casa', type: 'DESPESA', predefined: false };
 const receitaCategory: Category = { id: 'c2', name: 'Salário', type: 'RECEITA', predefined: false };
@@ -378,6 +379,111 @@ describe('TransactionsComponent', () => {
 
       expect(component.togglingId()).toBeNull();
       httpMock.expectNone((r) => r.url === '/api/transactions');
+    });
+  });
+
+  describe('seleção múltipla e ação em lote', () => {
+    beforeEach(() => {
+      component.transactions.set([
+        tx({ id: '1', status: 'PENDENTE', amountExpected: 100 }),
+        tx({ id: '2', status: 'PENDENTE', amountExpected: 200 }),
+      ]);
+    });
+
+    it('toggleSelect() adiciona e remove o id do conjunto selecionado', () => {
+      component.toggleSelect('1');
+      expect(component.isSelected('1')).toBeTrue();
+      component.toggleSelect('1');
+      expect(component.isSelected('1')).toBeFalse();
+    });
+
+    it('toggleSelectAll() seleciona todos os ids visíveis e, chamado de novo, desmarca todos', () => {
+      component.toggleSelectAll();
+      expect(component.selectedIds().size).toBe(2);
+      component.toggleSelectAll();
+      expect(component.selectedIds().size).toBe(0);
+    });
+
+    it('bulkUpdatePayment(true) marca cada id selecionado como pago, limpa a seleção e recarrega', () => {
+      component.toggleSelect('1');
+      component.toggleSelect('2');
+      component.bulkUpdatePayment(true);
+
+      const req1 = httpMock.expectOne('/api/transactions/1/payment');
+      expect(req1.request.body).toEqual({ amountPaid: 100 });
+      req1.flush(tx({ id: '1', status: 'PAGO', amountPaid: 100 }));
+
+      const req2 = httpMock.expectOne('/api/transactions/2/payment');
+      expect(req2.request.body).toEqual({ amountPaid: 200 });
+      req2.flush(tx({ id: '2', status: 'PAGO', amountPaid: 200 }));
+
+      httpMock.expectOne((r) => r.url === '/api/transactions').flush([]);
+
+      expect(component.selectedIds().size).toBe(0);
+    });
+
+    it('uma falha entre várias no lote não impede as demais de serem atualizadas', () => {
+      component.toggleSelect('1');
+      component.toggleSelect('2');
+      component.bulkUpdatePayment(true);
+
+      httpMock
+        .expectOne('/api/transactions/1/payment')
+        .flush('erro', { status: 500, statusText: 'Server Error' });
+      httpMock
+        .expectOne('/api/transactions/2/payment')
+        .flush(tx({ id: '2', status: 'PAGO', amountPaid: 200 }));
+
+      httpMock.expectOne((r) => r.url === '/api/transactions').flush([]);
+
+      expect(component.selectedIds().size).toBe(0);
+    });
+  });
+
+  describe('exclusão com desfazer', () => {
+    it('askDelete() mostra um toast com ação "Desfazer" e marca a linha como pendente de exclusão', () => {
+      const toast = TestBed.inject(ToastService);
+      spyOn(toast, 'actionable');
+
+      component.askDelete('1');
+
+      expect(component.pendingDeleteId()).toBe('1');
+      expect(toast.actionable).toHaveBeenCalledWith(
+        'Lançamento excluído.',
+        'warning',
+        jasmine.objectContaining({ label: 'Desfazer' }),
+      );
+    });
+
+    it('undoDelete() dentro da janela cancela a exclusão — nenhuma chamada DELETE é feita', () => {
+      jasmine.clock().install();
+      try {
+        component.askDelete('1');
+        component.undoDelete();
+        jasmine.clock().tick(4000);
+
+        expect(component.pendingDeleteId()).toBeNull();
+        httpMock.expectNone((r) => r.method === 'DELETE');
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
+
+    it('deixar o timer expirar sem desfazer exclui o lançamento de verdade', () => {
+      jasmine.clock().install();
+      try {
+        component.askDelete('1');
+        jasmine.clock().tick(4000);
+
+        const req = httpMock.expectOne('/api/transactions/1');
+        expect(req.request.method).toBe('DELETE');
+        req.flush(null);
+
+        httpMock.expectOne((r) => r.url === '/api/transactions').flush([]);
+        expect(component.pendingDeleteId()).toBeNull();
+      } finally {
+        jasmine.clock().uninstall();
+      }
     });
   });
 

--- a/src/app/features/transactions/transactions.component.ts
+++ b/src/app/features/transactions/transactions.component.ts
@@ -1,6 +1,8 @@
 import { Component, inject, signal, computed, OnInit, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
+import { forkJoin, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
 import { TransactionService, TransactionFilters } from '../../core/services/transaction.service';
 import { CategoryService } from '../../core/services/category.service';
 import { RecurringService } from '../../core/services/recurring.service';
@@ -20,6 +22,9 @@ const SORT_COLUMNS: readonly SortColumn[] = [
   'amountPaid',
   'dueDate',
 ];
+
+// mesma janela do auto-dismiss do ToastService (coincidência de valor, não acoplamento)
+const UNDO_DELETE_WINDOW_MS = 4000;
 
 // fronteira de confiança: o valor vem da URL, o usuário pode editá-la à mão
 function pickValid<T extends string>(value: string | null, allowed: readonly T[], fallback: T): T;
@@ -139,10 +144,11 @@ export class TransactionsComponent implements OnInit {
   readonly transactions = signal<Transaction[]>([]);
   readonly categories = signal<Category[]>([]);
   readonly loading = signal(false);
-  readonly deletingId = signal<string | null>(null);
-  readonly confirmDeleteId = signal<string | null>(null);
+  readonly pendingDeleteId = signal<string | null>(null);
   readonly generating = signal(false);
   readonly togglingId = signal<string | null>(null);
+  readonly selectedIds = signal<Set<string>>(new Set());
+  readonly bulkUpdating = signal(false);
 
   // Filtros — inicializados a partir dos query params da URL, pra sobreviver a navegação/reload
   readonly filterCategoryId = signal<string>(this.route.snapshot.queryParamMap.get('categoryId') ?? '');
@@ -162,6 +168,7 @@ export class TransactionsComponent implements OnInit {
   );
 
   private latestRequestId = 0;
+  private pendingDeleteTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     // Recarrega ao mudar mês/ano global
@@ -203,6 +210,7 @@ export class TransactionsComponent implements OnInit {
       year: year ?? y,
     };
 
+    this.selectedIds.set(new Set());
     const requestId = ++this.latestRequestId;
     this.loading.set(true);
     this.transactionService.getAll(filters).subscribe({
@@ -324,28 +332,31 @@ export class TransactionsComponent implements OnInit {
   }
 
   askDelete(id: string): void {
-    this.confirmDeleteId.set(id);
-  }
-  cancelDelete(): void {
-    this.confirmDeleteId.set(null);
+    this.pendingDeleteId.set(id);
+    this.pendingDeleteTimer = setTimeout(() => this.performDelete(id), UNDO_DELETE_WINDOW_MS);
+    this.toast.actionable('Lançamento excluído.', 'warning', {
+      label: 'Desfazer',
+      onClick: () => this.undoDelete(),
+    });
   }
 
-  confirmDelete(): void {
-    const id = this.confirmDeleteId();
-    if (!id) return;
-    this.deletingId.set(id);
+  undoDelete(): void {
+    if (this.pendingDeleteTimer) {
+      clearTimeout(this.pendingDeleteTimer);
+      this.pendingDeleteTimer = null;
+    }
+    this.pendingDeleteId.set(null);
+  }
+
+  private performDelete(id: string): void {
+    this.pendingDeleteTimer = null;
+    this.pendingDeleteId.set(null);
 
     this.transactionService.delete(id).subscribe({
-      next: () => {
-        this.toast.success('Lançamento excluído.');
-        this.confirmDeleteId.set(null);
-        this.deletingId.set(null);
-        this.load();
-      },
-      error: () => {
-        this.confirmDeleteId.set(null);
-        this.deletingId.set(null);
-      },
+      next: () => this.load(),
+      // errorInterceptor já mostra o erro (Fase 1, #35) — handler vazio só pro RxJS
+      // não relançar por falta de observer
+      error: () => {},
     });
   }
 
@@ -360,6 +371,58 @@ export class TransactionsComponent implements OnInit {
         this.load();
       },
       error: () => this.togglingId.set(null),
+    });
+  }
+
+  isSelected(id: string): boolean {
+    return this.selectedIds().has(id);
+  }
+
+  toggleSelect(id: string): void {
+    this.selectedIds.update((ids) => {
+      const next = new Set(ids);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  toggleSelectAll(): void {
+    const visibleIds = this.filtered().map((t) => t.id);
+    const allSelected = visibleIds.length > 0 && visibleIds.every((id) => this.selectedIds().has(id));
+    this.selectedIds.set(allSelected ? new Set() : new Set(visibleIds));
+  }
+
+  clearSelection(): void {
+    this.selectedIds.set(new Set());
+  }
+
+  bulkUpdatePayment(markAsPaid: boolean): void {
+    const targets = this.filtered().filter((t) => this.selectedIds().has(t.id));
+    if (targets.length === 0) return;
+
+    this.bulkUpdating.set(true);
+    const requests = targets.map((t) =>
+      this.transactionService.updatePayment(t.id, markAsPaid ? t.amountExpected : null).pipe(
+        map(() => ({ ok: true })),
+        catchError(() => of({ ok: false })),
+      ),
+    );
+
+    forkJoin(requests).subscribe((results) => {
+      this.bulkUpdating.set(false);
+      const failed = results.filter((r) => !r.ok).length;
+      const succeeded = results.length - failed;
+      if (failed === 0) {
+        this.toast.success(`${succeeded} lançamento(s) atualizado(s).`);
+      } else {
+        this.toast.warning(`${succeeded} atualizado(s), ${failed} falharam.`);
+      }
+      this.clearSelection();
+      this.load();
     });
   }
 }

--- a/src/app/shared/components/toast/toast.component.spec.ts
+++ b/src/app/shared/components/toast/toast.component.spec.ts
@@ -52,6 +52,31 @@ describe('ToastComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('.animate-slide-in').length).toBe(0);
   });
 
+  it('deve renderizar um botão de ação quando o toast tem action, e chamar onClick + dismiss ao clicar', () => {
+    const onClick = jasmine.createSpy('onClick');
+    toastService.actionable('Excluído.', 'warning', { label: 'Desfazer', onClick });
+    fixture.detectChanges();
+
+    const actionButton: HTMLButtonElement = fixture.nativeElement.querySelector(
+      '.animate-slide-in button.toast-action',
+    );
+    expect(actionButton).not.toBeNull();
+    expect(actionButton.textContent).toContain('Desfazer');
+
+    actionButton.click();
+    fixture.detectChanges();
+
+    expect(onClick).toHaveBeenCalled();
+    expect(toastService.toasts().length).toBe(0);
+  });
+
+  it('não deve renderizar botão de ação quando o toast não tem action', () => {
+    toastService.success('Salvo!');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.animate-slide-in button.toast-action')).toBeNull();
+  });
+
   describe('toastClass()', () => {
     it('deve retornar uma classe distinta por tipo', () => {
       const success = component.toastClass({ id: 1, message: '', type: 'success' });

--- a/src/app/shared/components/toast/toast.component.ts
+++ b/src/app/shared/components/toast/toast.component.ts
@@ -15,6 +15,14 @@ import { ToastService, Toast } from '../../services/toast.service';
         >
           <span class="text-lg">{{ toastIcon(toast.type) }}</span>
           <p class="text-sm font-medium flex-1">{{ toast.message }}</p>
+          @if (toast.action) {
+            <button
+              (click)="runAction(toast)"
+              class="toast-action text-current font-semibold text-sm underline underline-offset-2 hover:opacity-80 transition-opacity"
+            >
+              {{ toast.action.label }}
+            </button>
+          }
           <button
             (click)="toastService.dismiss(toast.id)"
             class="text-current opacity-50 hover:opacity-100 transition-opacity text-lg leading-none"
@@ -53,6 +61,11 @@ export class ToastComponent {
       warning: base + 'bg-[#1f1a09] border-[#f59e0b33] text-[#fbbf24]',
     };
     return map[toast.type] ?? map['success'];
+  }
+
+  runAction(toast: Toast): void {
+    toast.action?.onClick();
+    this.toastService.dismiss(toast.id);
   }
 
   toastIcon(type: string): string {

--- a/src/app/shared/services/toast.service.spec.ts
+++ b/src/app/shared/services/toast.service.spec.ts
@@ -35,6 +35,26 @@ describe('ToastService', () => {
     });
   });
 
+  describe('actionable()', () => {
+    it('deve criar um toast com a ação preenchida', () => {
+      const onClick = jasmine.createSpy('onClick');
+      service.actionable('Excluído.', 'warning', { label: 'Desfazer', onClick });
+
+      expect(service.toasts()[0]).toEqual(
+        jasmine.objectContaining({
+          message: 'Excluído.',
+          type: 'warning',
+          action: { label: 'Desfazer', onClick },
+        }),
+      );
+    });
+
+    it('success()/error()/warning() continuam sem ação', () => {
+      service.success('a');
+      expect(service.toasts()[0].action).toBeUndefined();
+    });
+  });
+
   describe('dismiss()', () => {
     it('deve remover apenas o toast com o id informado', () => {
       service.success('a');

--- a/src/app/shared/services/toast.service.ts
+++ b/src/app/shared/services/toast.service.ts
@@ -2,10 +2,16 @@ import { Injectable, signal } from '@angular/core';
 
 export type ToastType = 'success' | 'error' | 'warning';
 
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 export interface Toast {
   id: number;
   message: string;
   type: ToastType;
+  action?: ToastAction;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -26,13 +32,17 @@ export class ToastService {
     this.add(message, 'warning');
   }
 
+  actionable(message: string, type: ToastType, action: ToastAction): void {
+    this.add(message, type, action);
+  }
+
   dismiss(id: number): void {
     this._toasts.update((t) => t.filter((toast) => toast.id !== id));
   }
 
-  private add(message: string, type: ToastType): void {
+  private add(message: string, type: ToastType, action?: ToastAction): void {
     const id = this.nextId++;
-    this._toasts.update((t) => [...t, { id, message, type }]);
+    this._toasts.update((t) => [...t, { id, message, type, action }]);
     setTimeout(() => this.dismiss(id), 4000);
   }
 }


### PR DESCRIPTION
Closes #37

## Resumo
Seleção múltipla + ação em lote em Lançamentos, exclusão com "Desfazer" no lugar do modal de confirmação, e o padrão de busca/ordenação da issue #36 portado pra Recorrentes.

## Motivação
Marcar vários lançamentos como pago exigia um clique por linha. Excluir abria um modal bloqueante pra uma ação que dá pra desfazer. Recorrentes tinha uma tabela real do mesmo formato de Lançamentos sem busca nem ordenação.

## Mudanças
- Checkbox por linha + "selecionar todos os visíveis" + barra de ação em lote (marcar pago/pendente), reaproveitando `TransactionService.updatePayment` via `forkJoin` com `catchError` por item (mesmo padrão já usado em `DashboardComponent.load()`) — uma falha não impede as demais
- `Toast` ganha `action?: { label, onClick }` opcional; `ToastService.actionable()` novo método; `ToastComponent` renderiza o botão de ação
- Exclusão de lançamento (desktop e mobile) vira 1 clique com toast "Desfazer" — linha fica com opacidade reduzida e ações desabilitadas enquanto pendente; a chamada DELETE só dispara depois da janela sem desfazer
- Recorrentes ganha busca por descrição + ordenação clicável (Descrição/Categoria/Tipo/Valor padrão), sem persistência de URL (só Lançamentos precisa)

## Como testar
1. `npm start` (precisa do `aque-backend` rodando em `:8080`)
2. Lançamentos: selecionar algumas linhas, marcar em lote como pago; excluir um lançamento e clicar "Desfazer" antes de ~4s confirma que nada é excluído; deixar passar confirma que some
3. Recorrentes: busca e clique nas colunas funcionando

## Risco/Impacto
Nenhum — mudança só client-side, sem endpoint novo nem variável de ambiente.

## Screenshot/GIF
Diff toca UI em duas telas (`transactions`/`recurring`) — recomendo anexar screenshot/GIF antes do merge; não gerei um por não ter testado num navegador real nesta sessão.

## Checklist
- [x] Testes adicionados (`npm test`: 188/188 passando)
- [x] Docs atualizadas (spec em `docs/specs/37-...md`)
- [ ] Breaking changes: não
- [ ] Screenshot/GIF: pendente (ver acima)

🤖 Generated with [Claude Code](https://claude.com/claude-code)