### PR TITLE
test: fecha lacunas de cobertura encontradas pelo /spec-verify (specs #35, #36, #37)

### DIFF
--- a/src/app/features/recurring/recurring.component.html
+++ b/src/app/features/recurring/recurring.component.html
@@ -246,7 +246,7 @@
 
         <div class="ledger-form-group" style="margin-bottom: 0;">
           <label class="ledger-label">Dia do vencimento (opcional)</label>
-          <input class="ledger-input" type="number" min="1" max="31" [formField]="recurringForm.dueDay" placeholder="Ex: 10" />
+          <input class="ledger-input" type="number" [formField]="recurringForm.dueDay" placeholder="Ex: 10" />
           @if (recurringForm.dueDay().touched() && recurringForm.dueDay().invalid()) {
             <p class="ledger-error">{{ recurringForm.dueDay().errors()[0]?.message }}</p>
           }

--- a/src/app/features/transactions/transaction-form/transaction-form.component.spec.ts
+++ b/src/app/features/transactions/transaction-form/transaction-form.component.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { TransactionFormComponent } from './transaction-form.component';
 import { MonthYearService } from '../../../core/services/month-year.service';
 import { ToastService } from '../../../shared/services/toast.service';
@@ -190,6 +190,35 @@ describe('TransactionFormComponent', () => {
 
       expect(component.saving()).toBeFalse();
       expect(toast.error).not.toHaveBeenCalled();
+    });
+  });
+
+  // aque-web#35 (gap encontrado pelo /spec-verify): critério de aceite "abrir o formulário de
+  // edição com um id inexistente continua mostrando 'Lançamento não encontrado.' e voltando pra
+  // tela anterior" nunca tinha teste de regressão, antes ou depois da Fase 1.
+  describe('loadTransaction() — lançamento não encontrado na listagem', () => {
+    let http: HttpTestingController;
+
+    beforeEach(() => {
+      http = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => http.verify());
+
+    it('mostra "Lançamento não encontrado." e volta pra tela de lançamentos', () => {
+      const toast = TestBed.inject(ToastService);
+      const router = TestBed.inject(Router);
+      spyOn(toast, 'error');
+      spyOn(router, 'navigate');
+
+      http.expectOne((req) => req.url.includes('/api/categories')).flush([]);
+
+      component.loadTransaction('id-inexistente');
+      http.expectOne((req) => req.url.includes('/api/transactions')).flush([]);
+
+      expect(toast.error).toHaveBeenCalledWith('Lançamento não encontrado.');
+      expect(router.navigate).toHaveBeenCalledWith(['/transactions']);
+      expect(component.loading()).toBeFalse();
     });
   });
 

--- a/src/app/features/transactions/transactions.component.spec.ts
+++ b/src/app/features/transactions/transactions.component.spec.ts
@@ -143,6 +143,38 @@ describe('TransactionsComponent', () => {
       component.searchText.set('aluguel');
       expect(component.filtered().length).toBe(0);
     });
+
+    // gap encontrado pelo /spec-verify: os testes acima só chamavam searchText.set()
+    // direto, nunca o evento (input) real do campo de busca renderizado.
+    it('digitar no campo de busca (evento DOM real) filtra a tabela', () => {
+      fixture.detectChanges();
+      const input: HTMLInputElement = fixture.nativeElement.querySelector(
+        '.tx-filter-bar input[type="text"]',
+      );
+      input.value = 'supermercado';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(component.filtered().map((t) => t.id)).toEqual(['2']);
+    });
+
+    // gap: busca/sort/filtros nunca eram verificados contra os cards mobile,
+    // que consomem o mesmo filtered() mas são um bloco de template separado.
+    it('filtra também os cards mobile (mesmo filtered())', () => {
+      component.searchText.set('aluguel');
+      fixture.detectChanges(); // dispara o effect() do construtor (load() inicial)
+      httpMock
+        .expectOne((r) => r.url === '/api/transactions')
+        .flush([
+          tx({ id: '1', description: 'Aluguel de março', type: 'DESPESA' }),
+          tx({ id: '2', description: 'Supermercado', type: 'DESPESA' }),
+        ]);
+      fixture.detectChanges();
+
+      const cards = fixture.nativeElement.querySelectorAll('.tx-card-title');
+      expect(cards.length).toBe(1);
+      expect(cards[0].textContent).toContain('Aluguel de março');
+    });
   });
 
   describe('ordenação de colunas (setSort)', () => {
@@ -194,6 +226,44 @@ describe('TransactionsComponent', () => {
       ]);
       component.setSort('dueDate');
       expect(component.filtered().map((t) => t.id)).toEqual(['2', '3', '1']);
+    });
+
+    // gap encontrado pelo /spec-verify: setSort() era só chamado direto, nunca via
+    // clique real no <th>, e o indicador ▲/▼ nunca era verificado no DOM.
+    it('clicar no <th> Descrição ordena e mostra o indicador ▲, clicar de novo mostra ▼', () => {
+      fixture.detectChanges(); // dispara o effect() do construtor (load() inicial)
+      httpMock
+        .expectOne((r) => r.url === '/api/transactions')
+        .flush([tx({ id: '1', description: 'Banana' }), tx({ id: '2', description: 'Abacaxi' })]);
+      fixture.detectChanges();
+
+      const descriptionHeader: HTMLElement = fixture.nativeElement.querySelectorAll('th')[1];
+      descriptionHeader.click();
+      fixture.detectChanges();
+
+      expect(component.filtered().map((t) => t.id)).toEqual(['2', '1']);
+      expect(descriptionHeader.textContent).toContain('▲');
+
+      descriptionHeader.click();
+      fixture.detectChanges();
+
+      expect(descriptionHeader.textContent).toContain('▼');
+    });
+
+    // gap: nenhum teste combinava sort com um filtro de categoria/status ativo —
+    // só busca+tipo tinha esse cruzamento coberto.
+    it('ordenação opera só sobre os itens já filtrados por categoria/status', () => {
+      component.transactions.set([
+        tx({ id: '1', description: 'Zebra', category: despesaCategory, status: 'PENDENTE' }),
+        tx({ id: '2', description: 'Abacaxi', category: despesaCategory, status: 'PAGO' }),
+        tx({ id: '3', description: 'Mesa', category: receitaCategory, status: 'PENDENTE' }),
+      ]);
+      component.setFilterStatus('PENDENTE');
+      component.setSort('description');
+
+      // '2' está fora por causa do filtro de status, mesmo sendo alfabeticamente
+      // o primeiro — a ordenação nunca deveria trazê-lo de volta
+      expect(component.filtered().map((t) => t.id)).toEqual(['3', '1']);
     });
   });
 
@@ -301,6 +371,97 @@ describe('TransactionsComponent', () => {
           }),
         );
       });
+
+      // gap encontrado pelo /spec-verify: "Limpar filtros" só era testado no estado
+      // dos signals, nunca que a limpeza também é escrita na URL.
+      it('clearFilters() reflete na URL — todos os params voltam a null', () => {
+        const router = TestBed.inject(Router);
+        component.setFilterType('RECEITA');
+        component.setFilterStatus('PAGO');
+        component.setFilterCategory('c2');
+        component.searchText.set('luz');
+        component.toggleOverdue();
+        component.setSort('description');
+        fixture.detectChanges();
+        spyOn(router, 'navigate');
+
+        component.clearFilters();
+        fixture.detectChanges();
+
+        expect(router.navigate).toHaveBeenCalledWith(
+          [],
+          jasmine.objectContaining({
+            queryParams: {
+              categoryId: null,
+              type: null,
+              status: null,
+              search: null,
+              overdue: null,
+              sortBy: null,
+              sortDir: null,
+            },
+          }),
+        );
+      });
+    });
+
+    // gap: a leitura inicial e a escrita eram testadas separadamente, sem provar que
+    // os mesmos nomes/formatos de query param usados na escrita são os que a leitura
+    // espera de volta — o round-trip nunca era exercitado ponta a ponta.
+    it('round-trip: os params escritos na URL restauram o mesmo estado numa nova instância', () => {
+      const router = TestBed.inject(Router);
+      spyOn(router, 'navigate');
+
+      component.setFilterCategory('c1');
+      component.setFilterType('DESPESA');
+      component.setFilterStatus('PENDENTE');
+      component.searchText.set('luz');
+      component.toggleOverdue();
+      component.setSort('description');
+      fixture.detectChanges();
+
+      const lastCall = (router.navigate as jasmine.Spy).calls.mostRecent();
+      const writtenParams = lastCall.args[1].queryParams as Record<string, string | null>;
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [TransactionsComponent],
+        providers: [
+          provideHttpClient(),
+          provideHttpClientTesting(),
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useValue: { snapshot: { queryParamMap: convertToParamMap(writtenParams as Record<string, string>) } },
+          },
+        ],
+      });
+      const restoredFixture = TestBed.createComponent(TransactionsComponent);
+      const restored = restoredFixture.componentInstance;
+
+      expect(restored.filterCategoryId()).toBe('c1');
+      expect(restored.filterType()).toBe('DESPESA');
+      expect(restored.filterStatus()).toBe('PENDENTE');
+      expect(restored.searchText()).toBe('luz');
+      expect(restored.filterOverdue()).toBeTrue();
+      expect(restored.sortColumn()).toBe('description');
+    });
+
+    // gap: nenhum teste provava que trocar de mês preserva os filtros — verdade hoje
+    // só porque o effect() de recarga só chama load(), mas sem regressão automatizada.
+    it('trocar de mês/ano mantém os filtros ativos', () => {
+      component.setFilterType('DESPESA');
+      component.searchText.set('luz');
+      component.setSort('description');
+
+      const { month, year } = component.monthYear.selected();
+      const nextMonth = month === 12 ? 1 : month + 1;
+      const nextYear = month === 12 ? year + 1 : year;
+      component.monthYear.setMonthYear(nextMonth, nextYear);
+
+      expect(component.filterType()).toBe('DESPESA');
+      expect(component.searchText()).toBe('luz');
+      expect(component.sortColumn()).toBe('description');
     });
   });
 

--- a/src/app/features/transactions/transactions.component.ts
+++ b/src/app/features/transactions/transactions.component.ts
@@ -82,6 +82,16 @@ function compareByColumn(a: Transaction, b: Transaction, column: SortColumn): nu
     }
 
     /* ── Card layout ─────────────────────────────────────────── */
+    /* .ledger-table checkboxes: styles.css reseta appearance de todo input pra
+       permitir os inputs customizados (.ledger-input/.ledger-select) — um checkbox
+       sem aparência nativa e sem largura/altura própria fica invisível (0x0), então
+       precisa restaurar a aparência nativa aqui, escopado só a esses dois checkboxes. */
+    .ledger-table input[type="checkbox"] {
+      appearance: auto;
+      width: 16px;
+      height: 16px;
+      cursor: pointer;
+    }
     .tx-card {
       padding: 0.875rem 1rem;
       display: flex;


### PR DESCRIPTION
## Resumo
Fecha lacunas de cobertura de teste encontradas ao rodar `/spec-verify` retroativamente nas specs #35, #36 e #37 (já mergeadas), e corrige 2 bugs reais achados testando manualmente no navegador.

## Motivação
`/spec-verify` comparou o critério de aceite de cada spec contra evidência real (teste + navegador). A lógica de negócio estava bem coberta em todas, mas faltava a camada de "isso funciona de fato no DOM/no navegador" em vários pontos, e dois bugs reais só apareceram testando ao vivo.

## Mudanças

**Bugs reais corrigidos:**
- `recurring.component.html`: `npm start` não buildava (`NG8022` — `min`/`max` incompatíveis com `[formField]`), pré-existente desde a feature de dueDay, sem relação com o roadmap de UI/UX
- `transactions.component.ts`: checkboxes de seleção em lote (spec #37) renderizavam invisíveis (`0x0px`) por causa do reset CSS global `appearance: none` — só descoberto testando no navegador

**Testes de regressão (spec #35):**
- `transaction-form.component.spec.ts`: cobre o caso "lançamento não encontrado" (toast + navegação de volta), que nunca teve teste, antes ou depois da Fase 1

**Testes de cobertura (spec #36):**
- `transactions.component.spec.ts`: clique real no `<th>` + indicador ▲/▼ no DOM, digitação real no campo de busca, busca também filtrando os cards mobile, ordenação respeitando filtro de status ativo, round-trip real de query params (escreve → nova instância → restaura o mesmo estado), troca de mês preservando filtros, "Limpar filtros" refletindo na URL

## Como testar
1. `npm start` — confirma que builda sem erro agora
2. `npm test` — 196/196 passando

## Risco/Impacto
Nenhum em produção — só testes e 2 fixes de bugs já existentes (nenhuma mudança de comportamento novo).

## Checklist
- [x] Testes adicionados/corrigidos (`npm test`: 196/196 passando)
- [x] Docs atualizadas: n/a (sem mudança de spec/critério)
- [ ] Breaking changes: não

🤖 Generated with [Claude Code](https://claude.com/claude-code)