### PR TITLE
fix: address code review findings from PRs #43 and #44

### DIFF
--- a/.claude/docs/CONCERNS.md
+++ b/.claude/docs/CONCERNS.md
@@ -28,7 +28,23 @@
 
 ## Known Bugs
 
-None identified through static analysis. No open bug-tracking comments (`TODO`/`FIXME`/`HACK`/`XXX`) — grep matches on `'TODOS'` are false positives from the filter-enum value, not the marker.
+None currently open. One class of bug worth flagging as a recurring risk, found and fixed twice
+in the same week (`recurring.component.html`, issues #43/#44 follow-up):
+
+**`min`/`max` native attributes on an `<input>` bound with `[formField]` break the production
+build, undetected by `npm test`:**
+- Risk: Angular's template compiler raises `NG8022` ("Setting the 'min'/'max' attribute is not
+  allowed on nodes using the '[formField]' directive") only during AOT compilation (`ng build`/
+  `ng serve`) — Karma's JIT-based test runner (`npm test`) never exercises this code path, so a
+  reintroduction of this pattern passes the full test suite while breaking `npm start` and the
+  production build.
+- Files: any Signal Forms field (`[formField]="..."`) — don't add `min`/`max`/other native
+  validation attributes alongside it; range validation belongs in the field's `validate()`/
+  `min()`/`max()` Signal Forms functions instead (see `recurring.component.ts`'s `dueDay`
+  handling for the correct pattern).
+- Recommendations: `docker-publish.yml` doesn't run `npm run build` today (documented gap,
+  `standards.md`), so this class of bug has no CI safety net — a manual `npm start`/`ng build`
+  check before merging any Signal Forms template change is the only current mitigation.
 
 ## Security Considerations
 

--- a/docs/specs/45-fix-code-review-findings.md
+++ b/docs/specs/45-fix-code-review-findings.md
@@ -1,0 +1,161 @@
+# Corrige achados das revisões de código das PRs #43 e #44
+
+- **Issue:** #45 — https://github.com/BrininhoBru/aque-web/issues/45
+- **Status:** Draft
+- **Repo:** BrininhoBru/aque-web
+
+## Problema
+
+`/code-review` rodado nas PRs #43 (badge sidebar + paleta de comando) e #44 (fechamento de
+lacunas do `/spec-verify`), já mergeadas em `dev`, encontrou 9 pontos que não bloqueavam o merge
+mas valem correção: 1 duplicação de requisição HTTP, 1 bug de UX, 1 conflito de atalho de
+teclado, 1 lacuna de acessibilidade, 3 duplicações de código, 1 acoplamento frágil, e 2 lacunas
+de teste de regressão pra bugs já corrigidos.
+
+Nota de grounding: esta spec foi analisada contra `dev`, não `main` — o código revisado
+(`SidebarComponent`, `CommandPaletteComponent`, o fix de checkbox) só existe em `dev` hoje.
+`main` neste repo só avança via PR de release de `dev`, então analisar contra `main` teria
+comparado contra uma árvore sem nenhum desses arquivos.
+
+## Escopo
+
+**Dentro:**
+1. **Fetch duplicado do dashboard summary** (`sidebar.component.ts:174-185` e
+   `dashboard.component.ts:261-262`): `SidebarComponent` e `DashboardComponent` chamam
+   `DashboardService.getSummary(year, month)` de forma independente — na rota `/dashboard`,
+   ambos disparam a mesma requisição a cada troca de mês, dobrando a carga nesse endpoint
+2. **Cmd+K reabrindo a paleta já aberta zera a busca** (`command-palette.component.ts:88-92`):
+   `openPalette()` roda sem checar `this.open()`, descartando `query`/`activeIndex` em progresso
+3. **Atalho colide com Ctrl+Shift+K do Firefox** (`command-palette.component.ts:88`): o check
+   `(event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k'` não distingue
+   `Ctrl+Shift+K` de `Ctrl+K`, sequestrando o atalho nativo do Firefox de abrir o Console em
+   qualquer rota autenticada
+4. **Acessibilidade da paleta** (`command-palette.component.html`): overlay sem
+   `role="dialog"`/`aria-modal="true"`, sem focus trap (Tab escapa pro conteúdo atrás do
+   backdrop), sem devolver o foco ao elemento anterior ao fechar
+5. **Guarda de `requestId` triplicada**: o mesmo padrão manual (incrementar contador, comparar
+   na resposta pra descartar request obsoleta) existe hoje em `dashboard.component.ts`,
+   `transactions.component.ts` e `sidebar.component.ts:167,176,179` — extrair um helper
+   compartilhado
+6. **Backdrop da paleta duplicado do sidebar**: `command-palette.component.ts:22`
+   (`.command-palette-backdrop`) e `app-shell.component.ts:44` (`.sidebar-backdrop`) definem
+   `position: fixed; inset: 0` de forma independente — extrair a base comum (`fixed`/`inset:0`)
+   pra uma classe utilitária em `styles.css`, mantendo o resto (blur vs cor sólida, z-index) local
+   a cada um, já que servem propósitos visuais diferentes (modal centralizado vs scrim de drawer
+   mobile)
+7. **Badge hardcoded no loop de nav** (`sidebar.component.html`): o item que recebe o badge é
+   identificado comparando a string literal `'/transactions'` dentro do `@for` genérico —
+   estender `NavItem` (`nav-items.ts:1-5`) com um campo opcional que carregue essa associação
+8. **Helper de teste duplicado**: a função `press(key, opts)` (dispatch de `KeyboardEvent` em
+   `window`) está copiada verbatim em `command-palette.component.spec.ts` e
+   `app-shell.component.spec.ts`
+9. **Factory de mock duplicada**: `sidebar.component.spec.ts` define `summary(overrides)` pra
+   montar um `DashboardSummary` mock; `app-shell.component.spec.ts` escreve os mesmos 10 campos
+   na mão em vez de reusar
+10. **Regressão do fix de checkbox invisível** (`transactions.component.ts:89-91`): o fix já
+    mergeado (CSS `appearance: auto` nos checkboxes de seleção) não tem teste que trave o
+    tamanho/aparência renderizada — viola a regra de TDD do time pra código legado alterado
+11. **Regressão do fix de build NG8022**: o fix em `recurring.component.html` (remoção de
+    `min`/`max` incompatíveis com `[formField]`) não é detectável pela suíte Karma atual — o
+    `npm test` faz compilação JIT, não a checagem AOT de template que gerou o erro original;
+    `docker-publish.yml` também não roda `npm run build` hoje
+
+**Fora:**
+- Não introduzir um serviço de cache genérico entre `DashboardService` e seus consumidores — o
+  fix do item 1 é local (mover a leitura do badge pra reusar o dado que `DashboardComponent` já
+  tem quando ambos estão montados, ou aceitar duas chamadas quando estão em rotas diferentes;
+  ver Abordagem). Uma camada de cache com invalidação é over-engineering pro volume de uma app
+  pessoal e introduz risco de dado desatualizado depois de uma mutação (ex.: marcar pago)
+- Não adicionar `npm run build` ao CI (`docker-publish.yml`) neste PR — é a mitigação real pro
+  item 11, mas é uma mudança de infraestrutura de CI, decisão separada de "corrigir os achados
+  da revisão"; a spec só cobre deixar isso documentado e, quando possível, coberto por teste
+- Não construir um componente de overlay/dialog genérico reutilizável (ex.: um `<app-modal>`)
+  — o item 6 pede só extrair a base `fixed;inset:0` compartilhada, não uma abstração de dialog
+- Não mudar o comportamento do atalho em si além de excluir Shift/Alt — não adicionar
+  customização de atalho (fora de escopo já na spec #38 original)
+
+## Abordagem
+
+**Item 1 (fetch duplicado):** `SidebarComponent` está montado globalmente em
+`AppShellComponent`, então em rotas que não são `/dashboard` ele já é a única fonte da chamada
+— duplicação só ocorre quando o usuário está na própria rota `/dashboard`. Solução lazy:
+`DashboardService` ganha um `resource()`/signal compartilhado só pra `getSummary` (o método mais
+chamado por consumidores diferentes), usando `rxResource` ou um `shareReplay({ bufferSize: 1,
+refCount: true })` por chave `year-month` que expira quando não há mais subscribers — sem cache
+persistente entre navegações, só deduplicação de chamadas concorrentes/quase-simultâneas.
+`SidebarComponent` e `DashboardComponent` passam a consumir esse observable compartilhado em vez
+de cada um chamar `http.get` direto.
+
+**Item 2 (Cmd+K reabre):** guarda em `onKeydown` —
+`if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') { event.preventDefault(); if (!this.open()) this.openPalette(); return; }`.
+
+**Item 3 (Ctrl+Shift+K):** adicionar `&& !event.shiftKey && !event.altKey` ao mesmo check.
+
+**Item 4 (acessibilidade):** `command-palette.component.html` — `role="dialog"` e
+`aria-modal="true"` no painel; foco inicial já vai pro input (`afterRenderEffect` existente,
+`command-palette.component.ts:78-84`), falta capturar o elemento com foco antes de abrir
+(`document.activeElement`) e devolver o foco a ele em `close()`. Focus trap: um handler de Tab
+simples ciclando entre o input e os itens da lista (sem lib nova — poucos elementos focáveis).
+
+**Item 5 (guarda de requestId):** extrair uma função utilitária pequena (não um serviço/classe)
+em algum lugar compartilhado como `core/rxjs/latest-request-guard.ts` — ex.:
+`createLatestRequestGuard()` retornando `{ next(): id, isCurrent(id): boolean }` — e substituir o
+padrão manual nos 3 pontos.
+
+**Item 6 (backdrop):** classe `.overlay-backdrop { position: fixed; inset: 0; z-index: ...; }`
+em `styles.css` (seguindo o padrão de utilitário já usado ali, `.ledger-*`); cada componente
+mantém sua cor/blur/z-index específicos combinando com a classe base.
+
+**Item 7 (badge hardcoded):** `NavItem` (`nav-items.ts`) ganha `badgeSignal?: () => number` ou,
+mais simples e sem acoplar `nav-items.ts` a Angular signals importados de fora, um campo
+`badgeKey?: string` que o `SidebarComponent` usa pra decidir qual signal local mostrar — decisão
+de implementação exata fica pro momento de codar, mas o loop do template deixa de comparar a
+string de path.
+
+**Item 8 e 9 (duplicação em specs):** mover `press()` e `summary()` pra um arquivo de fixture
+compartilhado (ex.: `src/app/layout/test-helpers.ts` para `press`, já que é específico de
+teclado/layout; `summary()` pode ir para perto de `DashboardSummary` em
+`core/models`-adjacent test helpers, ou simplesmente ser exportada de
+`dashboard.component.spec.ts` e importada por quem precisar — decisão de local exata na
+implementação, seguindo o padrão de fixtures locais já usado no repo).
+
+**Item 10 (regressão checkbox):** teste em `transactions.component.spec.ts` que renderiza a
+tabela e verifica `offsetWidth`/`offsetHeight` > 0 (ou `getComputedStyle(...).appearance !==
+'none'`) nos dois checkboxes (cabeçalho "selecionar todos" e linha).
+
+**Item 11 (regressão build):** como Karma não pega isso, a mitigação realista é documentação —
+um comentário no arquivo (`recurring.component.html`) já existe implicitamente pela natureza do
+fix; adicionar uma nota no `CONCERNS.md` do repo (gap de CI já documentado) referenciando este
+padrão especificamente (`min`/`max` nativo + `[formField]`) como algo a não reintroduzir. Ver
+"Fora de escopo" — adicionar `npm run build` ao CI fica para decisão separada.
+
+## Critério de aceite
+
+- [ ] Na rota `/dashboard`, `DashboardService.getSummary` é chamado no máximo uma vez por
+      mudança de mês/ano (verificável em teste via `HttpTestingController.expectOne`, não
+      `expectOne` falhando por chamada dupla)
+- [ ] Apertar Cmd/Ctrl+K com a paleta já aberta não altera `query()`/`activeIndex()` correntes
+- [ ] `Ctrl+Shift+K` (ou `Cmd+Shift+K`) não abre a paleta nem chama `preventDefault()`
+- [ ] O painel da paleta tem `role="dialog"` e `aria-modal="true"`; fechar a paleta (Esc, Enter
+      ou seleção) devolve o foco ao elemento que estava focado antes de abrir
+- [ ] Tab dentro da paleta aberta não move o foco para elementos fora dela
+- [ ] `dashboard.component.ts`, `transactions.component.ts` e `sidebar.component.ts` usam o
+      mesmo helper de guarda de request obsoleta, não 3 implementações manuais separadas
+- [ ] `.command-palette-backdrop` e `.sidebar-backdrop` compartilham a declaração
+      `position:fixed;inset:0` via uma classe/regra comum, sem repetir os mesmos valores
+      literais duas vezes
+- [ ] O `@for` de navegação em `sidebar.component.html` não compara `item.path === '/transactions'`
+      como string literal — a associação do badge à rota vem do próprio `NavItem`
+- [ ] `press()` e `summary()` existem em um só lugar, importados pelos specs que precisam, não
+      duplicados
+- [ ] Um teste cobre que os checkboxes de seleção em lote renderizam com dimensão/aparência
+      visível (não 0x0), cobrindo o fix já mergeado
+- [ ] `.claude/docs/CONCERNS.md` (ou equivalente) documenta que `min`/`max` nativo junto de
+      `[formField]` quebra o build de produção sem ser pego pela suíte de testes atual
+
+## Questões em aberto
+
+- Mecanismo exato de dedup do item 1 (`rxResource` vs `shareReplay` manual) — decidir no momento
+  da implementação, ambos atendem o critério de aceite igualmente
+- Local exato dos arquivos compartilhados dos itens 5, 8 e 9 — qualquer local consistente com a
+  convenção de fixtures/utilitários já usada no repo serve

--- a/src/app/core/rxjs/latest-request-guard.spec.ts
+++ b/src/app/core/rxjs/latest-request-guard.spec.ts
@@ -1,0 +1,29 @@
+import { createLatestRequestGuard } from './latest-request-guard';
+
+describe('createLatestRequestGuard', () => {
+  it('o id mais recente é o único considerado atual', () => {
+    const guard = createLatestRequestGuard();
+    const first = guard.next();
+    const second = guard.next();
+
+    expect(guard.isCurrent(first)).toBeFalse();
+    expect(guard.isCurrent(second)).toBeTrue();
+  });
+
+  it('ids são incrementais e distintos', () => {
+    const guard = createLatestRequestGuard();
+    const first = guard.next();
+    const second = guard.next();
+    expect(second).toBeGreaterThan(first);
+  });
+
+  it('guards independentes não compartilham estado', () => {
+    const guardA = createLatestRequestGuard();
+    const guardB = createLatestRequestGuard();
+
+    const idA = guardA.next();
+    guardB.next();
+
+    expect(guardA.isCurrent(idA)).toBeTrue();
+  });
+});

--- a/src/app/core/rxjs/latest-request-guard.ts
+++ b/src/app/core/rxjs/latest-request-guard.ts
@@ -1,0 +1,10 @@
+// Padrão repetido em dashboard.component.ts, transactions.component.ts e
+// sidebar.component.ts (achado do /code-review, PR #43): descarta a resposta de uma
+// requisição obsoleta quando uma mais recente já foi disparada (ex.: troca rápida de mês).
+export function createLatestRequestGuard() {
+  let latest = 0;
+  return {
+    next: (): number => ++latest,
+    isCurrent: (id: number): boolean => id === latest,
+  };
+}

--- a/src/app/core/services/dashboard.service.spec.ts
+++ b/src/app/core/services/dashboard.service.spec.ts
@@ -43,6 +43,44 @@ describe('DashboardService', () => {
       expect(req.request.method).toBe('GET');
       req.flush(summary);
     });
+
+    // achado do /code-review na PR #43: SidebarComponent e DashboardComponent chamam
+    // getSummary independentemente pro mesmo year/month na rota /dashboard, dobrando
+    // a carga nesse endpoint a cada troca de mês.
+    it('deduplica chamadas concorrentes pro mesmo year/month — só 1 requisição HTTP', () => {
+      let first: DashboardSummary | undefined;
+      let second: DashboardSummary | undefined;
+      service.getSummary(2026, 3).subscribe((res) => (first = res));
+      service.getSummary(2026, 3).subscribe((res) => (second = res));
+
+      const req = http.expectOne('/api/dashboard/summary/2026/3');
+      req.flush(summary);
+
+      expect(first).toEqual(summary);
+      expect(second).toEqual(summary);
+    });
+
+    it('não reusa o cache pra year/month diferentes — 2 requisições HTTP', () => {
+      service.getSummary(2026, 3).subscribe();
+      service.getSummary(2026, 4).subscribe();
+
+      const req1 = http.expectOne('/api/dashboard/summary/2026/3');
+      const req2 = http.expectOne('/api/dashboard/summary/2026/4');
+      expect(req1).not.toBe(req2);
+      req1.flush(summary);
+      req2.flush(summary);
+    });
+
+    it('uma nova chamada após a anterior completar dispara uma nova requisição (sem cache permanente)', () => {
+      service.getSummary(2026, 3).subscribe();
+      http.expectOne('/api/dashboard/summary/2026/3').flush(summary);
+
+      let result: DashboardSummary | undefined;
+      service.getSummary(2026, 3).subscribe((res) => (result = res));
+      http.expectOne('/api/dashboard/summary/2026/3').flush(summary);
+
+      expect(result).toEqual(summary);
+    });
   });
 
   describe('getByCategory()', () => {

--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -21,10 +21,14 @@ export class DashboardService {
     let summary$ = this.summaryCache.get(key);
     if (!summary$) {
       summary$ = this.http.get<DashboardSummary>(`${this.base}/summary/${year}/${month}`).pipe(
-        // shareReplay não reseta ao completar (só ao refCount zerar de forma "ativa"),
-        // então sem isso a entrada vira um cache permanente — finalize() evicta a
-        // chave assim que a requisição compartilhada termina (sucesso ou erro),
-        // garantindo que só concorre entre chamadas simultâneas, não entre navegações
+        // shareReplay's refCount:true reset é guardado por !hasCompleted internamente
+        // (rxjs/internal/operators/share.js) — como uma fonte que completa (toda
+        // requisição HTTP) já seta hasCompleted=true antes do teardown do subscriber
+        // rodar, o reset por refCount-zero nunca dispara sozinho aqui, e sem
+        // finalize() a entrada vira cache permanente (confirmado lendo o share.js e
+        // testando: sem isso, uma 2ª chamada sequencial não gera 2ª requisição HTTP).
+        // finalize() evicta a chave assim que a requisição compartilhada termina
+        // (sucesso ou erro), garantindo que só concorre entre chamadas simultâneas.
         finalize(() => this.summaryCache.delete(key)),
         shareReplay({ bufferSize: 1, refCount: true }),
       );

--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { finalize, shareReplay } from 'rxjs/operators';
 import { DashboardSummary, CategoryTotal, MonthEvolution, SplitResult } from '../models';
 import { environment } from '../../../environments/environment';
 
@@ -9,8 +10,27 @@ export class DashboardService {
   private readonly http = inject(HttpClient);
   private readonly base = `${environment.apiBaseUrl}/api/dashboard`;
 
+  // SidebarComponent e DashboardComponent chamam getSummary independentemente pro
+  // mesmo year/month (achado do /code-review, PR #43) — shareReplay com refCount
+  // deduplica chamadas concorrentes sem manter cache permanente entre navegações
+  // (o buffer é descartado quando o último subscriber sai).
+  private readonly summaryCache = new Map<string, Observable<DashboardSummary>>();
+
   getSummary(year: number, month: number): Observable<DashboardSummary> {
-    return this.http.get<DashboardSummary>(`${this.base}/summary/${year}/${month}`);
+    const key = `${year}-${month}`;
+    let summary$ = this.summaryCache.get(key);
+    if (!summary$) {
+      summary$ = this.http.get<DashboardSummary>(`${this.base}/summary/${year}/${month}`).pipe(
+        // shareReplay não reseta ao completar (só ao refCount zerar de forma "ativa"),
+        // então sem isso a entrada vira um cache permanente — finalize() evicta a
+        // chave assim que a requisição compartilhada termina (sucesso ou erro),
+        // garantindo que só concorre entre chamadas simultâneas, não entre navegações
+        finalize(() => this.summaryCache.delete(key)),
+        shareReplay({ bufferSize: 1, refCount: true }),
+      );
+      this.summaryCache.set(key, summary$);
+    }
+    return summary$;
   }
 
   getByCategory(

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -23,6 +23,7 @@ import { MonthYearService } from '../../core/services/month-year.service';
 import { BrlCurrencyPipe } from '../../shared/pipes/brl-currency.pipe';
 import { MonthYearPipe } from '../../shared/pipes/month-year.pipe';
 import { DashboardSummary, CategoryTotal, MonthEvolution, SplitResult } from '../../core/models';
+import { createLatestRequestGuard } from '../../core/rxjs/latest-request-guard';
 
 export type PieChartOptions = {
   series: ApexNonAxisChartSeries;
@@ -244,7 +245,7 @@ export class DashboardComponent {
     };
   });
 
-  private latestRequestId = 0;
+  private readonly requestGuard = createLatestRequestGuard();
 
   constructor() {
     effect(() => {
@@ -254,7 +255,7 @@ export class DashboardComponent {
   }
 
   load(year: number, month: number): void {
-    const requestId = ++this.latestRequestId;
+    const requestId = this.requestGuard.next();
     this.loading.set(true);
     this.splitError.set(false);
 
@@ -272,7 +273,7 @@ export class DashboardComponent {
       ),
     }).subscribe({
       next: (data) => {
-        if (requestId !== this.latestRequestId) return; // resposta obsoleta, ignora
+        if (!this.requestGuard.isCurrent(requestId)) return; // resposta obsoleta, ignora
         this.summary.set(data.summary);
         this.byCategory.set(data.byCategory);
         this.evolution.set(data.evolution);
@@ -280,7 +281,7 @@ export class DashboardComponent {
         this.loading.set(false);
       },
       error: () => {
-        if (requestId !== this.latestRequestId) return;
+        if (!this.requestGuard.isCurrent(requestId)) return;
         this.loading.set(false);
       },
     });

--- a/src/app/features/split/split.component.ts
+++ b/src/app/features/split/split.component.ts
@@ -9,6 +9,7 @@ import { ToastService } from '../../shared/services/toast.service';
 import { BrlCurrencyPipe } from '../../shared/pipes/brl-currency.pipe';
 import { MonthYearPipe } from '../../shared/pipes/month-year.pipe';
 import { Person } from '../../core/models';
+import { createLatestRequestGuard } from '../../core/rxjs/latest-request-guard';
 
 interface PersonSplit {
   person: Person;
@@ -62,7 +63,7 @@ export class SplitComponent implements OnInit {
   readonly saving = signal(false);
   readonly totalExpenseExpected = signal<number>(0);
 
-  private latestExpensesRequestId = 0;
+  private readonly expensesRequestGuard = createLatestRequestGuard();
 
   // Soma total dos percentuais em tempo real — arredonda pra 2 casas decimais (mesma
   // escala dos inputs) pra não deixar ruído de ponto flutuante rejeitar uma soma que já
@@ -132,14 +133,14 @@ export class SplitComponent implements OnInit {
   }
 
   loadExpenses(year: number, month: number): void {
-    const requestId = ++this.latestExpensesRequestId;
+    const requestId = this.expensesRequestGuard.next();
     this.dashboardService.getSummary(year, month).subscribe({
       next: (s) => {
-        if (requestId !== this.latestExpensesRequestId) return; // resposta obsoleta, ignora
+        if (!this.expensesRequestGuard.isCurrent(requestId)) return; // resposta obsoleta, ignora
         this.totalExpenseExpected.set(s.totalExpenseExpected);
       },
       error: () => {
-        if (requestId !== this.latestExpensesRequestId) return;
+        if (!this.expensesRequestGuard.isCurrent(requestId)) return;
         this.totalExpenseExpected.set(0);
       },
     });

--- a/src/app/features/transactions/transactions.component.spec.ts
+++ b/src/app/features/transactions/transactions.component.spec.ts
@@ -551,6 +551,30 @@ describe('TransactionsComponent', () => {
       ]);
     });
 
+    // achado do /code-review na PR #44: o fix do checkbox invisível (0x0px, CSS
+    // appearance:none global) foi mergeado sem teste de regressão — standards.md
+    // exige teste antes de mexer em código legado sem cobertura.
+    //
+    // Usa getComputedStyle (não offsetWidth/offsetHeight): a tabela desktop tem
+    // "hidden md:block" e o viewport padrão do Karma/ChromeHeadless fica abaixo do
+    // breakpoint md, então offsetWidth zeraria por causa do display:none responsivo,
+    // não pela regra de appearance que é o que este teste precisa travar.
+    it('os checkboxes de seleção têm appearance nativa, não appearance:none', () => {
+      fixture.detectChanges();
+      httpMock.expectOne((r) => r.url === '/api/transactions').flush([
+        tx({ id: '1', status: 'PENDENTE' }),
+      ]);
+      fixture.detectChanges();
+
+      const checkboxes: NodeListOf<HTMLInputElement> = fixture.nativeElement.querySelectorAll(
+        'input[type="checkbox"]',
+      );
+      expect(checkboxes.length).toBeGreaterThan(0);
+      checkboxes.forEach((checkbox) => {
+        expect(getComputedStyle(checkbox).appearance).not.toBe('none');
+      });
+    });
+
     it('toggleSelect() adiciona e remove o id do conjunto selecionado', () => {
       component.toggleSelect('1');
       expect(component.isSelected('1')).toBeTrue();

--- a/src/app/features/transactions/transactions.component.ts
+++ b/src/app/features/transactions/transactions.component.ts
@@ -10,6 +10,7 @@ import { ToastService } from '../../shared/services/toast.service';
 import { MonthYearService } from '../../core/services/month-year.service';
 import { Transaction, Category } from '../../core/models';
 import { BrlCurrencyPipe } from '../../shared/pipes/brl-currency.pipe';
+import { createLatestRequestGuard } from '../../core/rxjs/latest-request-guard';
 
 type FilterType = 'TODOS' | 'RECEITA' | 'DESPESA';
 type FilterStatus = 'TODOS' | 'PENDENTE' | 'PAGO';
@@ -177,7 +178,7 @@ export class TransactionsComponent implements OnInit {
     pickValid(this.route.snapshot.queryParamMap.get('sortDir'), ['asc', 'desc'], 'asc'),
   );
 
-  private latestRequestId = 0;
+  private readonly requestGuard = createLatestRequestGuard();
   private pendingDeleteTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
@@ -221,16 +222,16 @@ export class TransactionsComponent implements OnInit {
     };
 
     this.selectedIds.set(new Set());
-    const requestId = ++this.latestRequestId;
+    const requestId = this.requestGuard.next();
     this.loading.set(true);
     this.transactionService.getAll(filters).subscribe({
       next: (data) => {
-        if (requestId !== this.latestRequestId) return; // resposta obsoleta, ignora
+        if (!this.requestGuard.isCurrent(requestId)) return; // resposta obsoleta, ignora
         this.transactions.set(data);
         this.loading.set(false);
       },
       error: () => {
-        if (requestId !== this.latestRequestId) return;
+        if (!this.requestGuard.isCurrent(requestId)) return;
         this.loading.set(false);
       },
     });

--- a/src/app/layout/app-shell/app-shell.component.html
+++ b/src/app/layout/app-shell/app-shell.component.html
@@ -2,7 +2,7 @@
   <app-sidebar />
 
   @if (layout.sidebarOpen()) {
-    <div class="sidebar-backdrop" (click)="layout.close()"></div>
+    <div class="overlay-backdrop sidebar-backdrop" (click)="layout.close()"></div>
   }
 
   <div class="app-shell-content">

--- a/src/app/layout/app-shell/app-shell.component.spec.ts
+++ b/src/app/layout/app-shell/app-shell.component.spec.ts
@@ -3,9 +3,26 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { AppShellComponent } from './app-shell.component';
+import { DashboardSummary } from '../../core/models';
+import { press } from '../test-helpers';
 
-function press(key: string, opts: Partial<KeyboardEventInit> = {}): void {
-  window.dispatchEvent(new KeyboardEvent('keydown', { key, ...opts }));
+// factory local por arquivo de spec (convenção do time, ver .claude/rules/testing.md) —
+// achado do /code-review na PR #43 era o literal de 10 campos escrito na mão, não a
+// ausência de uma fixture compartilhada
+function summary(overrides: Partial<DashboardSummary>): DashboardSummary {
+  return {
+    totalIncomeExpected: 0,
+    totalIncomePaid: 0,
+    totalExpenseExpected: 0,
+    totalExpensePaid: 0,
+    balanceExpected: 0,
+    balancePaid: 0,
+    totalIncomePending: 0,
+    totalExpensePending: 0,
+    totalOverdueAmount: 0,
+    totalOverdueCount: 0,
+    ...overrides,
+  };
 }
 
 describe('AppShellComponent', () => {
@@ -23,18 +40,7 @@ describe('AppShellComponent', () => {
     fixture.detectChanges();
     // sidebar dispara a carga do badge de pendências ao montar — flush pra não
     // deixar request pendente
-    httpMock.expectOne((r) => r.url.includes('/api/dashboard/summary')).flush({
-      totalIncomeExpected: 0,
-      totalIncomePaid: 0,
-      totalExpenseExpected: 0,
-      totalExpensePaid: 0,
-      balanceExpected: 0,
-      balancePaid: 0,
-      totalIncomePending: 0,
-      totalExpensePending: 0,
-      totalOverdueAmount: 0,
-      totalOverdueCount: 0,
-    });
+    httpMock.expectOne((r) => r.url.includes('/api/dashboard/summary')).flush(summary({}));
   });
 
   it('deve criar o shell com a paleta de comando montada', () => {

--- a/src/app/layout/app-shell/app-shell.component.ts
+++ b/src/app/layout/app-shell/app-shell.component.ts
@@ -53,8 +53,6 @@ import { LayoutService } from '../layout.service';
       }
       .sidebar-backdrop {
         display: block;
-        position: fixed;
-        inset: 0;
         z-index: 40;
         background: rgba(0, 0, 0, 0.5);
       }

--- a/src/app/layout/command-palette/command-palette.component.html
+++ b/src/app/layout/command-palette/command-palette.component.html
@@ -1,6 +1,12 @@
 @if (open()) {
-  <div class="command-palette-backdrop" (click)="close()">
-    <div class="command-palette ledger-card" (click)="$event.stopPropagation()">
+  <div class="overlay-backdrop command-palette-backdrop" (click)="close()">
+    <div
+      class="command-palette ledger-card"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Ir para..."
+      (click)="$event.stopPropagation()"
+    >
       <input
         #queryInput
         type="text"

--- a/src/app/layout/command-palette/command-palette.component.spec.ts
+++ b/src/app/layout/command-palette/command-palette.component.spec.ts
@@ -1,10 +1,7 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { Router, provideRouter } from '@angular/router';
 import { CommandPaletteComponent } from './command-palette.component';
-
-function press(key: string, opts: Partial<KeyboardEventInit> = {}): void {
-  window.dispatchEvent(new KeyboardEvent('keydown', { key, ...opts }));
-}
+import { press } from '../test-helpers';
 
 describe('CommandPaletteComponent', () => {
   let component: CommandPaletteComponent;
@@ -39,6 +36,20 @@ describe('CommandPaletteComponent', () => {
     press('k', { ctrlKey: true });
     fixture.detectChanges();
     expect(component.open()).toBeTrue();
+  });
+
+  // achado do /code-review na PR #43: (metaKey||ctrlKey)+'k' não distinguia
+  // Ctrl+Shift+K, sequestrando o atalho nativo do Firefox de abrir o Console.
+  it('Ctrl+Shift+K não abre a paleta', () => {
+    press('k', { ctrlKey: true, shiftKey: true });
+    fixture.detectChanges();
+    expect(component.open()).toBeFalse();
+  });
+
+  it('Cmd+Alt+K não abre a paleta', () => {
+    press('k', { metaKey: true, altKey: true });
+    fixture.detectChanges();
+    expect(component.open()).toBeFalse();
   });
 
   // gap encontrado pelo /spec-verify: nenhum teste provava que digitação normal
@@ -81,6 +92,70 @@ describe('CommandPaletteComponent', () => {
     });
   });
 
+  // achado do /code-review na PR #43: overlay sem role/aria-modal, sem devolver o
+  // foco ao elemento anterior ao fechar, sem focus trap.
+  describe('acessibilidade', () => {
+    it('o painel tem role="dialog" e aria-modal="true"', () => {
+      press('k', { metaKey: true });
+      fixture.detectChanges();
+
+      const panel: HTMLElement = fixture.nativeElement.querySelector('.command-palette');
+      expect(panel.getAttribute('role')).toBe('dialog');
+      expect(panel.getAttribute('aria-modal')).toBe('true');
+    });
+
+    it('devolve o foco ao elemento anterior quando fecha com Escape', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      try {
+        press('k', { metaKey: true });
+        fixture.detectChanges();
+        expect(document.activeElement).not.toBe(trigger);
+
+        press('Escape');
+        fixture.detectChanges();
+
+        expect(document.activeElement).toBe(trigger);
+      } finally {
+        document.body.removeChild(trigger);
+      }
+    });
+
+    it('devolve o foco ao elemento anterior quando fecha selecionando um item', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      try {
+        press('k', { metaKey: true });
+        fixture.detectChanges();
+
+        component.selectItem(component.items()[0]);
+        fixture.detectChanges();
+
+        expect(document.activeElement).toBe(trigger);
+      } finally {
+        document.body.removeChild(trigger);
+      }
+    });
+
+    it('Tab não escapa a paleta — mantém o foco no input de busca', () => {
+      press('k', { metaKey: true });
+      fixture.detectChanges();
+
+      const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+      const preventDefaultSpy = spyOn(tabEvent, 'preventDefault').and.callThrough();
+      window.dispatchEvent(tabEvent);
+      fixture.detectChanges();
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('.command-palette-input');
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
   describe('com a paleta aberta', () => {
     beforeEach(() => {
       press('k', { metaKey: true });
@@ -99,6 +174,18 @@ describe('CommandPaletteComponent', () => {
     it('digitar filtra a lista por label, case-insensitive', () => {
       component.setQuery('lança');
       expect(component.items().map((i) => i.label)).toEqual(['Lançamentos']);
+    });
+
+    // achado do /code-review na PR #43: apertar Cmd/Ctrl+K de novo com a paleta já
+    // aberta rodava openPalette() incondicionalmente, zerando query/activeIndex em
+    // progresso.
+    it('apertar Cmd+K de novo com a paleta já aberta não reseta a busca em progresso', () => {
+      component.setQuery('cat');
+      press('k', { metaKey: true });
+      fixture.detectChanges();
+
+      expect(component.open()).toBeTrue();
+      expect(component.query()).toBe('cat');
     });
 
     it('ArrowDown/ArrowUp movem o item ativo sem passar dos limites', () => {

--- a/src/app/layout/command-palette/command-palette.component.ts
+++ b/src/app/layout/command-palette/command-palette.component.ts
@@ -20,8 +20,6 @@ const ALL_ITEMS: NavItem[] = [...MAIN_NAV, ...SECONDARY_NAV];
   templateUrl: './command-palette.component.html',
   styles: [`
     .command-palette-backdrop {
-      position: fixed;
-      inset: 0;
       z-index: 60;
       display: flex;
       align-items: flex-start;
@@ -74,6 +72,7 @@ export class CommandPaletteComponent {
   });
 
   private readonly queryInput = viewChild<ElementRef<HTMLInputElement>>('queryInput');
+  private previouslyFocused: HTMLElement | null = null;
 
   constructor() {
     afterRenderEffect(() => {
@@ -85,9 +84,14 @@ export class CommandPaletteComponent {
 
   @HostListener('window:keydown', ['$event'])
   onKeydown(event: KeyboardEvent): void {
-    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      !event.shiftKey &&
+      !event.altKey &&
+      event.key.toLowerCase() === 'k'
+    ) {
       event.preventDefault();
-      this.openPalette();
+      if (!this.open()) this.openPalette();
       return;
     }
 
@@ -95,6 +99,10 @@ export class CommandPaletteComponent {
 
     if (event.key === 'Escape') {
       this.close();
+    } else if (event.key === 'Tab') {
+      // único elemento focável hoje é o input de busca — "trap" é mantê-lo focado
+      event.preventDefault();
+      this.queryInput()?.nativeElement.focus();
     } else if (event.key === 'ArrowDown') {
       event.preventDefault();
       this.activeIndex.update((i) => Math.min(i + 1, this.items().length - 1));
@@ -118,6 +126,7 @@ export class CommandPaletteComponent {
   }
 
   private openPalette(): void {
+    this.previouslyFocused = document.activeElement as HTMLElement;
     this.query.set('');
     this.activeIndex.set(0);
     this.open.set(true);
@@ -125,5 +134,7 @@ export class CommandPaletteComponent {
 
   close(): void {
     this.open.set(false);
+    this.previouslyFocused?.focus();
+    this.previouslyFocused = null;
   }
 }

--- a/src/app/layout/nav-items.ts
+++ b/src/app/layout/nav-items.ts
@@ -2,6 +2,9 @@ export interface NavItem {
   path: string;
   label: string;
   icon: string;
+  // chave que a sidebar usa pra decidir qual badge (se algum) mostrar nesse item —
+  // evita comparar item.path por string literal fora deste arquivo
+  badgeKey?: string;
 }
 
 export const MAIN_NAV: NavItem[] = [
@@ -14,6 +17,7 @@ export const MAIN_NAV: NavItem[] = [
     path: '/transactions',
     label: 'Lançamentos',
     icon: `<svg width="16" height="16" fill="currentColor" viewBox="0 0 24 24"><path d="M19 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V5a2 2 0 00-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l7.59-7.59L21 8l-9 9z"/></svg>`,
+    badgeKey: 'overdue',
   },
 ];
 

--- a/src/app/layout/sidebar/sidebar.component.html
+++ b/src/app/layout/sidebar/sidebar.component.html
@@ -25,7 +25,7 @@
       <a [routerLink]="item.path" routerLinkActive="nav-active" class="nav-link" (click)="onNavClick()">
         <span [innerHTML]="item.icon"></span>
         <span>{{ item.label }}</span>
-        @if (item.path === '/transactions' && overdueCount() > 0) {
+        @if (item.badgeKey === 'overdue' && overdueCount() > 0) {
           <span class="sidebar-badge">{{ overdueCount() }}</span>
         }
       </a>

--- a/src/app/layout/sidebar/sidebar.component.ts
+++ b/src/app/layout/sidebar/sidebar.component.ts
@@ -4,6 +4,7 @@ import { LayoutService } from '../layout.service';
 import { MAIN_NAV, SECONDARY_NAV } from '../nav-items';
 import { DashboardService } from '../../core/services/dashboard.service';
 import { MonthYearService } from '../../core/services/month-year.service';
+import { createLatestRequestGuard } from '../../core/rxjs/latest-request-guard';
 
 @Component({
   selector: 'app-sidebar',
@@ -164,7 +165,7 @@ export class SidebarComponent {
   readonly secondaryNav = SECONDARY_NAV;
   readonly overdueCount = signal(0);
 
-  private latestRequestId = 0;
+  private readonly requestGuard = createLatestRequestGuard();
 
   @HostBinding('class.sidebar-closed') get isClosed() {
     return !this.layout.sidebarOpen();
@@ -173,10 +174,10 @@ export class SidebarComponent {
   constructor() {
     effect(() => {
       const { month, year } = this.monthYear.selected();
-      const requestId = ++this.latestRequestId;
+      const requestId = this.requestGuard.next();
       this.dashboardService.getSummary(year, month).subscribe({
         next: (data) => {
-          if (requestId !== this.latestRequestId) return;
+          if (!this.requestGuard.isCurrent(requestId)) return;
           this.overdueCount.set(data.totalOverdueCount);
         },
         // errorInterceptor já mostra o erro (Fase 1, #35)

--- a/src/app/layout/test-helpers.ts
+++ b/src/app/layout/test-helpers.ts
@@ -1,0 +1,5 @@
+// Compartilhado entre command-palette.component.spec.ts e app-shell.component.spec.ts
+// (achado do /code-review, PR #43) — ambos simulam o atalho global de teclado.
+export function press(key: string, opts: Partial<KeyboardEventInit> = {}): void {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, ...opts }));
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -507,6 +507,15 @@ app-header {
     gap: 0.5rem;
     flex-wrap: wrap;
   }
+
+  /* ── Overlay backdrop ────────────────────────────────────── */
+  /* base compartilhada por .sidebar-backdrop e .command-palette-backdrop —
+     cada um combina com essa classe pra herdar position:fixed;inset:0 e define
+     z-index/cor/blur próprios, já que servem propósitos visuais diferentes */
+  .overlay-backdrop {
+    position: fixed;
+    inset: 0;
+  }
   .cards-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));


### PR DESCRIPTION
Closes #45

## Resumo
Corrige os 11 achados combinados das revisões `/code-review` das PRs #43 (badge sidebar + paleta de comando) e #44 (fechamento de lacunas do `/spec-verify`), já mergeadas em `dev`.

## Motivação
Nenhum dos achados bloqueava o merge original, mas incluíam 3 bugs de comportamento real (fetch duplicado, Cmd+K resetando busca em progresso, conflito de atalho com o Firefox), 1 lacuna de acessibilidade, 3 duplicações de código e 2 lacunas de teste de regressão pra bugs já corrigidos.

## Mudanças
- **`DashboardService.getSummary`**: dedup de requisições concorrentes via `shareReplay` + `finalize()` (evita cache permanente/dado desatualizado)
- **Paleta de comando**: Cmd/Ctrl+K não reseta mais a busca se já aberta; `Ctrl+Shift+K` não sequestra mais o atalho do Firefox; `role="dialog"`/`aria-modal`, devolve foco ao fechar, Tab não escapa
- **`createLatestRequestGuard()`** (novo, `core/rxjs/`): elimina 3 cópias manuais do padrão de guarda contra resposta obsoleta
- **`.overlay-backdrop`** compartilhado entre sidebar e paleta; badge da sidebar usa `NavItem.badgeKey` em vez de comparar path como string
- **Regressão** pro fix de checkbox invisível (usa `getComputedStyle`, não `offsetWidth` — viewport padrão do Karma fica abaixo do breakpoint `md`, então `offsetWidth` mascararia o teste)
- **`CONCERNS.md`**: documenta o gap de cobertura do bug `min`/`max` + `[formField]` (não detectável pela suíte Karma atual)

**Desvio da spec original**: não extraí `summary()` (fixture de `DashboardSummary`) pra um arquivo compartilhado como a spec/revisão sugeriam — `.claude/rules/testing.md` documenta explicitamente "sem diretório de fixtures compartilhado, factory local por spec" como convenção deliberada do time. Em vez disso, `app-shell.component.spec.ts` ganhou sua própria factory local (o problema real era os 10 campos escritos na mão, não a falta de compartilhamento).

## Como testar
1. `npm test` — 227/227 passando
2. Manual (confirmado nesta sessão): Cmd+K com texto digitado + Cmd+K de novo não reseta a busca; `Ctrl+Shift+K` não abre a paleta; Esc fecha e devolve o foco

## Risco/Impacto
Nenhum — mudanças são correções/refactors sobre comportamento já existente, sem novo endpoint nem breaking change. `shareReplay` é a única mudança de runtime não trivial; coberta por 3 testes dedicados (dedup concorrente, chaves diferentes, sem cache permanente).

## Checklist
- [x] Testes adicionados/corrigidos (`npm test`: 227/227 passando)
- [x] Docs atualizadas (`CONCERNS.md`, spec em `docs/specs/45-...md`)
- [ ] Breaking changes: não

🤖 Generated with [Claude Code](https://claude.com/claude-code)