### PR TITLE
fix(sidebar): desativa badge de lançamentos vencidos no menu

### DIFF
--- a/src/app/layout/nav-items.ts
+++ b/src/app/layout/nav-items.ts
@@ -17,7 +17,8 @@ export const MAIN_NAV: NavItem[] = [
     path: '/transactions',
     label: 'Lançamentos',
     icon: `<svg width="16" height="16" fill="currentColor" viewBox="0 0 24 24"><path d="M19 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V5a2 2 0 00-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l7.59-7.59L21 8l-9 9z"/></svg>`,
-    badgeKey: 'overdue',
+    // ponytail: badge de "vencidos" (badgeKey: 'overdue') desativada — o dado é global, não por
+    // mês, e confundia o usuário no dashboard mensal. Redesenhar antes de reativar.
   },
 ];
 

--- a/src/app/layout/sidebar/sidebar.component.html
+++ b/src/app/layout/sidebar/sidebar.component.html
@@ -25,9 +25,6 @@
       <a [routerLink]="item.path" routerLinkActive="nav-active" class="nav-link" (click)="onNavClick()">
         <span [innerHTML]="item.icon"></span>
         <span>{{ item.label }}</span>
-        @if (item.badgeKey === 'overdue' && overdueCount() > 0) {
-          <span class="sidebar-badge">{{ overdueCount() }}</span>
-        }
       </a>
     }
 

--- a/src/app/layout/sidebar/sidebar.component.spec.ts
+++ b/src/app/layout/sidebar/sidebar.component.spec.ts
@@ -1,99 +1,28 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { provideHttpClient } from '@angular/common/http';
-import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { SidebarComponent } from './sidebar.component';
-import { MonthYearService } from '../../core/services/month-year.service';
-import { DashboardSummary } from '../../core/models';
-
-function summary(overrides: Partial<DashboardSummary>): DashboardSummary {
-  return {
-    totalIncomeExpected: 0,
-    totalIncomePaid: 0,
-    totalExpenseExpected: 0,
-    totalExpensePaid: 0,
-    balanceExpected: 0,
-    balancePaid: 0,
-    totalIncomePending: 0,
-    totalExpensePending: 0,
-    totalOverdueAmount: 0,
-    totalOverdueCount: 0,
-    ...overrides,
-  };
-}
 
 describe('SidebarComponent', () => {
   let component: SidebarComponent;
   let fixture: ComponentFixture<SidebarComponent>;
-  let httpMock: HttpTestingController;
-  let monthYear: MonthYearService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SidebarComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+      providers: [provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SidebarComponent);
     component = fixture.componentInstance;
-    httpMock = TestBed.inject(HttpTestingController);
-    monthYear = TestBed.inject(MonthYearService);
   });
 
   it('deve criar o componente', () => {
     fixture.detectChanges();
-    httpMock.expectOne((r) => r.url.includes('/api/dashboard/summary')).flush(summary({}));
     expect(component).toBeTruthy();
   });
 
-  describe('badge de pendências (overdueCount)', () => {
-    it('mostra o badge com totalOverdueCount quando > 0', () => {
-      fixture.detectChanges();
-      const { month, year } = monthYear.selected();
-      httpMock
-        .expectOne((r) => r.url === `/api/dashboard/summary/${year}/${month}`)
-        .flush(summary({ totalOverdueCount: 3 }));
-      fixture.detectChanges();
-
-      expect(component.overdueCount()).toBe(3);
-      const badge = fixture.nativeElement.querySelector('.sidebar-badge');
-      expect(badge).not.toBeNull();
-      expect(badge.textContent).toContain('3');
-    });
-
-    it('não mostra badge quando totalOverdueCount é 0', () => {
-      fixture.detectChanges();
-      const { month, year } = monthYear.selected();
-      httpMock
-        .expectOne((r) => r.url === `/api/dashboard/summary/${year}/${month}`)
-        .flush(summary({ totalOverdueCount: 0 }));
-      fixture.detectChanges();
-
-      expect(fixture.nativeElement.querySelector('.sidebar-badge')).toBeNull();
-    });
-
-    it('trocar de mês atualiza o badge pro valor do novo mês', () => {
-      fixture.detectChanges();
-      const { month, year } = monthYear.selected();
-      httpMock
-        .expectOne((r) => r.url === `/api/dashboard/summary/${year}/${month}`)
-        .flush(summary({ totalOverdueCount: 1 }));
-
-      const nextMonth = month === 12 ? 1 : month + 1;
-      const nextYear = month === 12 ? year + 1 : year;
-      monthYear.setMonthYear(nextMonth, nextYear);
-      fixture.detectChanges();
-
-      httpMock
-        .expectOne((r) => r.url === `/api/dashboard/summary/${nextYear}/${nextMonth}`)
-        .flush(summary({ totalOverdueCount: 5 }));
-      fixture.detectChanges();
-
-      expect(component.overdueCount()).toBe(5);
-      // gap encontrado pelo /spec-verify: só o signal era reverificado, nunca o
-      // badge renderizado de fato no DOM após a troca de mês.
-      const badge = fixture.nativeElement.querySelector('.sidebar-badge');
-      expect(badge.textContent).toContain('5');
-    });
+  it('não renderiza badge de pendências no menu (desativada, ver #32)', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.sidebar-badge')).toBeNull();
   });
 });

--- a/src/app/layout/sidebar/sidebar.component.ts
+++ b/src/app/layout/sidebar/sidebar.component.ts
@@ -1,10 +1,7 @@
-import { Component, HostBinding, inject, signal, effect } from '@angular/core';
+import { Component, HostBinding, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { LayoutService } from '../layout.service';
 import { MAIN_NAV, SECONDARY_NAV } from '../nav-items';
-import { DashboardService } from '../../core/services/dashboard.service';
-import { MonthYearService } from '../../core/services/month-year.service';
-import { createLatestRequestGuard } from '../../core/rxjs/latest-request-guard';
 
 @Component({
   selector: 'app-sidebar',
@@ -109,20 +106,6 @@ import { createLatestRequestGuard } from '../../core/rxjs/latest-request-guard';
       background: var(--color-ledger-side-active);
       border-radius: 0 2px 2px 0;
     }
-    .sidebar-badge {
-      margin-left: auto;
-      min-width: 1.25rem;
-      height: 1.25rem;
-      padding: 0 0.375rem;
-      border-radius: 999px;
-      background: #ef4444;
-      color: white;
-      font-size: 0.7rem;
-      font-weight: 600;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
     .sidebar-footer {
       padding: 0.75rem;
       border-top: 1px solid rgba(255,255,255,0.08);
@@ -158,32 +141,12 @@ import { createLatestRequestGuard } from '../../core/rxjs/latest-request-guard';
 })
 export class SidebarComponent {
   private readonly layout = inject(LayoutService);
-  private readonly dashboardService = inject(DashboardService);
-  private readonly monthYear = inject(MonthYearService);
 
   readonly mainNav = MAIN_NAV;
   readonly secondaryNav = SECONDARY_NAV;
-  readonly overdueCount = signal(0);
-
-  private readonly requestGuard = createLatestRequestGuard();
 
   @HostBinding('class.sidebar-closed') get isClosed() {
     return !this.layout.sidebarOpen();
-  }
-
-  constructor() {
-    effect(() => {
-      const { month, year } = this.monthYear.selected();
-      const requestId = this.requestGuard.next();
-      this.dashboardService.getSummary(year, month).subscribe({
-        next: (data) => {
-          if (!this.requestGuard.isCurrent(requestId)) return;
-          this.overdueCount.set(data.totalOverdueCount);
-        },
-        // errorInterceptor já mostra o erro (Fase 1, #35)
-        error: () => {},
-      });
-    });
   }
 
   onNavClick(): void {


### PR DESCRIPTION
## Resumo
Remove a badge de "vencidos" do menu "Lançamentos" no sidebar, junto com a lógica que só existia pra alimentá-la.

## Motivação
A contagem de vencidos (`totalOverdueCount`) é global no backend — não escopada por mês/ano — enquanto o dashboard é filtrado por período. Isso fazia a badge mudar sem relação nenhuma com o mês selecionado, confundindo o usuário.

Ao investigar (ver `BrininhoBru/aque-backend#32`, fechada como "não é bug"), achei um teste de integração já existente no backend cujo nome documenta esse comportamento global como **intencional** (uma dívida antiga continua valendo mesmo navegando por outro mês). Decisão: não mudar o backend agora — desativar a exibição no frontend até redesenhar a feature com calma (quando/se ela deve variar por período).

## Mudanças
- `nav-items.ts`: removido `badgeKey: 'overdue'` do item "Lançamentos" (comentário `ponytail:` documentando a decisão e apontando pra issue)
- `sidebar.component.html`: removido o bloco que renderizava a badge
- `sidebar.component.ts`: removida a lógica que só existia pra alimentar a badge — fetch de `dashboardService.getSummary` a cada troca de mês, signal `overdueCount`, `effect`, CSS `.sidebar-badge` — pra não deixar código morto
- `sidebar.component.spec.ts`: testes da badge removidos/substituídos por um teste que confirma que ela não renderiza mais

## Como testar
```bash
CHROME_BIN=/usr/bin/brave-browser npx ng test --include='**/sidebar.component.spec.ts' --watch=false --browsers=ChromeHeadless
```
Ou visualmente: abrir o app, checar que o menu "Lançamentos" não mostra mais nenhuma badge, independente de haver despesas vencidas.

## Risco/Impacto
Nenhum. Não muda contrato com o `aque-backend` (nenhuma rota/payload alterado), não adiciona variável de ambiente nova, é só remoção de UI + código morto no frontend.

## Screenshot/GIF
Diff toca `sidebar.component.html`/`.ts` (visual) — recomendo anexar um screenshot do sidebar sem a badge antes do merge.

## Checklist
- [x] `ng test` (arquivo do sidebar) passando localmente
- [x] Sem breaking changes
- [x] Sem TODOs/débito não documentado (débito documentado via comentário `ponytail:` + issue linkada)
- [ ] Issue linkada: não aplicável neste repo — issue relacionada está em `BrininhoBru/aque-backend#32` (fechada)